### PR TITLE
just name/description, not project_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,8 @@ nomic login [token]
 
 Make your first map:
 ```python
-from nomic import AtlasClient
+from nomic import atlas
 import numpy as np
-
-atlas = AtlasClient()
 
 num_embeddings = 10000
 embeddings = np.random.rand(num_embeddings, 256)

--- a/docs/data_cleaning_in_atlas.md
+++ b/docs/data_cleaning_in_atlas.md
@@ -38,8 +38,8 @@ The dataset is composed of news articles scraped by an [academic news scraping e
     project = atlas.map_text(data=documents,
                              id_field='id',
                              indexed_field='text',
-                             map_name='News 10k Labeling Example',
-                             map_description='10k News Articles for Labeling'
+                             name='News 10k Labeling Example',
+                             description='10k News Articles for Labeling'
                              )
     print(project.maps)
     ```

--- a/docs/dynamic_maps.md
+++ b/docs/dynamic_maps.md
@@ -35,7 +35,7 @@ the embedding was part of the first or second set of data added to the project.
     project = atlas.map_embeddings(embeddings=embeddings,
                                    data=data,
                                    id_field='id',
-                                   map_name='A Map That Gets Updated',
+                                   name='A Map That Gets Updated',
                                    colorable_fields=['upload'],
                                    reset_project_if_exists=True)
 

--- a/docs/map_your_text.md
+++ b/docs/map_your_text.md
@@ -25,9 +25,9 @@ When sending text you should specify an `indexed_field` in the `map_text` functi
     
     project = atlas.map_text(data=documents,
                               indexed_field='text',
-                              map_name='News 10k Example',
+                              name='News 10k Example',
                               colorable_fields=['label'],
-                              map_description='News 10k Example.'
+                              description='News 10k Example.'
                               )
     ```
 
@@ -85,8 +85,8 @@ This code snippet is a complete example of how to make a map with a HuggingFace 
     response = atlas.map_embeddings(embeddings=embeddings,
                                     data=documents,
                                     colorable_fields=['sentiment'],
-                                    map_name="Huggingface Model Example",
-                                    map_description="An example of building a text map with a huggingface model.")
+                                    name="Huggingface Model Example",
+                                    description="An example of building a text map with a huggingface model.")
     
     print(response)
     ```
@@ -142,8 +142,8 @@ Add your Cohere API key to the below example to see how their large language mod
     response = atlas.map_embeddings(embeddings=np.array(embeddings),
                                     data=documents,
                                     colorable_fields=['sentiment'],
-                                    map_name='Sentiment 140',
-                                    map_description='A 10,000 point sample of the huggingface sentiment140 dataset embedded with the co:here small model.',
+                                    name='Sentiment 140',
+                                    description='A 10,000 point sample of the huggingface sentiment140 dataset embedded with the co:here small model.',
                                     )
     print(response)
     ```

--- a/docs/vector_search_in_atlas.md
+++ b/docs/vector_search_in_atlas.md
@@ -49,9 +49,9 @@ for idx, document in enumerate(documents):
 project = atlas.map_text(data=documents,
                          indexed_field='text',
                          id_field='id',
-                         map_name='News Dataset 25k',
+                         name='News Dataset 25k',
                          colorable_fields=['label'],
-                         map_description='News Dataset 25k'
+                         description='News Dataset 25k'
                           )
 
 ```

--- a/examples/interactive_session.py
+++ b/examples/interactive_session.py
@@ -10,9 +10,9 @@ documents = [dataset[i] for i in subset_idxs]
 
 project = atlas.map_text(data=documents,
                           indexed_field='text',
-                          map_name='News Dataset 25k',
+                          name='News Dataset 25k',
                           colorable_fields=['label'],
-                          map_description='News Dataset 25k'
+                          description='News Dataset 25k'
                           )
 
 

--- a/examples/map_embeddings_progressively.py
+++ b/examples/map_embeddings_progressively.py
@@ -10,7 +10,7 @@ data = [{'upload': '1'} for i in range(len(embeddings))]
 
 project = atlas.map_embeddings(embeddings=embeddings,
                                data=data,
-                               map_name='A Map That Gets Updated',
+                               name='A Map That Gets Updated',
                                colorable_fields=['upload'])
 map = project.get_map('A Map That Gets Updated')
 print(map)

--- a/examples/map_hf_dataset_with_cohere.py
+++ b/examples/map_hf_dataset_with_cohere.py
@@ -24,7 +24,7 @@ print("Embedding job complete.")
 response = atlas.map_embeddings(embeddings=np.array(embeddings),
                                 data=documents,
                                 colorable_fields=['sentiment'],
-                                map_name='Sentiment 140',
-                                map_description='A 10,000 point sample of the huggingface sentiment140 dataset embedded with cohere',
+                                name='Sentiment 140',
+                                description='A 10,000 point sample of the huggingface sentiment140 dataset embedded with cohere',
                                 )
 print(response)

--- a/examples/map_text.py
+++ b/examples/map_text.py
@@ -10,9 +10,9 @@ documents = [dataset[i] for i in subset_idxs]
 
 project = atlas.map_text(data=documents,
                           indexed_field='text',
-                          map_name='News 10k Example',
+                          name='News 10k Example',
                           colorable_fields=['label'],
-                          map_description='News 10k Example from the ag_news dataset hosted on huggingface.'
+                          description='News 10k Example from the ag_news dataset hosted on huggingface.'
                           )
 print(project.maps)
 

--- a/examples/map_text_progressively.py
+++ b/examples/map_text_progressively.py
@@ -13,7 +13,7 @@ second_upload = documents[500:]
 
 project = atlas.map_text(data=first_upload,
                           indexed_field='text',
-                          map_name='News 1k Example Progressive',
+                          name='News 1k Example Progressive',
                           num_workers=10)
 
 print(project.maps)

--- a/examples/map_wikipedia.py
+++ b/examples/map_wikipedia.py
@@ -10,7 +10,7 @@ documents = [dataset[i] for i in subset_idxs]
 
 response = atlas.map_text(data=documents,
                           indexed_field='text',
-                          map_name='Wiki 10K',
-                          map_description='A 10,000 point sample of the huggingface wikipedia dataset embedded with Nomic\'s Embed v0.0.13 model.',
+                          name='Wiki 10K',
+                          description='A 10,000 point sample of the huggingface wikipedia dataset embedded with Nomic\'s Embed v0.0.13 model.',
                           build_topic_model=True)
 print(response)

--- a/examples/map_with_huggingface.py
+++ b/examples/map_with_huggingface.py
@@ -30,8 +30,8 @@ print(embeddings.shape)
 response = atlas.map_embeddings(embeddings=embeddings,
                                 data=documents,
                                 colorable_fields=['sentiment'],
-                                map_name="Huggingface Model Example",
-                                map_description="An example of building a text map with a huggingface model.")
+                                name="Huggingface Model Example",
+                                description="An example of building a text map with a huggingface model.")
 
 print(response)
 

--- a/nomic/atlas.py
+++ b/nomic/atlas.py
@@ -18,8 +18,8 @@ def map_embeddings(
     embeddings: np.array,
     data: List[Dict] = None,
     id_field: str = None,
-    map_name: str = None,
-    map_description: str = None,
+    name: str = None,
+    description: str = None,
     is_public: bool = True,
     colorable_fields: list = [],
     build_topic_model: bool = True,
@@ -39,8 +39,8 @@ def map_embeddings(
         embeddings: An [N,d] numpy array containing the batch of N embeddings to add.
         data: An [N,] element list of dictionaries containing metadata for each embedding.
         id_field: Specify your data unique id field. This field can be up 36 characters in length. If not specified, one will be created for you named `id_`.
-        map_name: A name for your map.
-        map_description: A description for your map.
+        name: A name for your map.
+        description: A description for your map.
         is_public: Should this embedding map be public? Private maps can only be accessed by members of your organization.
         colorable_fields: The project fields you want to be able to color by on the map. Must be a subset of the projects fields.
         organization_name: The name of the organization to create this project under. You must be a member of the organization with appropriate permissions. If not specified, defaults to your user accounts default organization.
@@ -64,11 +64,11 @@ def map_embeddings(
     description = 'A description for your map.'
     index_name = project_name
 
-    if map_name:
-        project_name = map_name
-        index_name = map_name
-    if map_description:
-        description = map_description
+    if name:
+        project_name = name
+        index_name = name
+    if description:
+        description = description
 
     if data is None:
         data = [{} for _ in range(len(embeddings))]
@@ -134,8 +134,8 @@ def map_text(
     data: List[Dict],
     indexed_field: str,
     id_field: str = None,
-    map_name: str = None,
-    map_description: str = None,
+    name: str = None,
+    description: str = None,
     build_topic_model: bool = True,
     multilingual: bool = False,
     is_public: bool = True,
@@ -156,8 +156,8 @@ def map_text(
         data: An [N,] element list of dictionaries containing metadata for each embedding.
         indexed_field: The name the data field containing the text your want to map.
         id_field: Specify your data unique id field. This field can be up 36 characters in length. If not specified, one will be created for you named `id_`.
-        map_name: A name for your map.
-        map_description: A description for your map.
+        name: A name for your map.
+        description: A description for your map.
         build_topic_model: Builds a hierarchical topic model over your data to discover patterns.
         multilingual: Should the map take language into account? If true, points from different with semantically similar text are considered similar.
         is_public: Should this embedding map be public? Private maps can only be accessed by members of your organization.
@@ -180,11 +180,11 @@ def map_text(
     description = 'A description for your map.'
     index_name = project_name
 
-    if map_name:
-        project_name = map_name
-        index_name = map_name
-    if map_description:
-        description = map_description
+    if name:
+        project_name = name
+        index_name = name
+    if description:
+        description = description
 
     project = AtlasProject(
         name=project_name,

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -20,14 +20,14 @@ def test_map_embeddings_with_errors():
     with pytest.raises(Exception):
         data = [{'hello': {'hello'}} for i in range(len(embeddings))]
         response = atlas.map_embeddings(
-            embeddings=embeddings, data=data, map_name='UNITTEST1', is_public=True, reset_project_if_exists=True
+            embeddings=embeddings, data=data, name='UNITTEST1', is_public=True, reset_project_if_exists=True
         )
 
     # test underscore
     with pytest.raises(Exception):
         data = [{'__hello': {'hello'}} for i in range(len(embeddings))]
         response = atlas.map_embeddings(
-            embeddings=embeddings, data=data, map_name='UNITTEST1', is_public=True, reset_project_if_exists=True
+            embeddings=embeddings, data=data, name='UNITTEST1', is_public=True, reset_project_if_exists=True
         )
 
     # test non-matching keys across metadatums
@@ -35,7 +35,7 @@ def test_map_embeddings_with_errors():
         data = [{'hello': 'a'} for i in range(len(embeddings))]
         data[1]['goodbye'] = 'b'
         response = atlas.map_embeddings(
-            embeddings=embeddings, data=data, map_name='UNITTEST1', is_public=True, reset_project_if_exists=True
+            embeddings=embeddings, data=data, name='UNITTEST1', is_public=True, reset_project_if_exists=True
         )
 
     # test to long ids
@@ -44,7 +44,7 @@ def test_map_embeddings_with_errors():
         response = atlas.map_embeddings(
             embeddings=embeddings,
             data=data,
-            map_name='UNITTEST1',
+            name='UNITTEST1',
             id_field='id',
             is_public=True,
             reset_project_if_exists=True,
@@ -55,7 +55,7 @@ def test_map_embeddings_with_errors():
         data = [{'b': 'a'} for i in range(len(embeddings))]
         data[1]['goodbye'] = 'b'
         response = atlas.map_embeddings(
-            embeddings=embeddings, data=data, map_name='UNITTEST1', is_public=True, reset_project_if_exists=True
+            embeddings=embeddings, data=data, name='UNITTEST1', is_public=True, reset_project_if_exists=True
         )
 
     # fail on to large metadata
@@ -63,7 +63,7 @@ def test_map_embeddings_with_errors():
         embeddings = np.random.rand(1000, 10)
         data = [{'string': ''.join(['a'] * (1048576 // 10))} for _ in range(len(embeddings))]
         response = atlas.map_embeddings(
-            embeddings=embeddings, data=data, map_name='UNITTEST1', is_public=True, reset_project_if_exists=True
+            embeddings=embeddings, data=data, name='UNITTEST1', is_public=True, reset_project_if_exists=True
         )
 
 
@@ -74,7 +74,7 @@ def test_map_embeddings():
 
     project = atlas.map_embeddings(
         embeddings=embeddings,
-        map_name='UNITTEST1',
+        name='UNITTEST1',
         id_field='id',
         data=data,
         is_public=True,
@@ -110,7 +110,7 @@ def test_date_metadata():
     data = [{'my_date': datetime.datetime(2022, 1, i).isoformat()} for i in range(1, len(embeddings) + 1)]
 
     project = atlas.map_embeddings(
-        embeddings=embeddings, map_name='UNITTEST1', data=data, is_public=True, reset_project_if_exists=True
+        embeddings=embeddings, name='UNITTEST1', data=data, is_public=True, reset_project_if_exists=True
     )
 
     assert project.id
@@ -122,7 +122,7 @@ def test_date_metadata():
         data[1]['my_date'] = data[1]['my_date'] + 'asdf'
         project = atlas.map_embeddings(
             embeddings=embeddings,
-            map_name='UNITTEST1',
+            name='UNITTEST1',
             id_field='id',
             data=data,
             is_public=True,
@@ -138,8 +138,8 @@ def test_map_text_errors():
             data=[{'key': 'a'}],
             indexed_field='text',
             is_public=True,
-            map_name='UNITTEST1',
-            map_description='test map description',
+            name='UNITTEST1',
+            description='test map description',
             num_workers=1,
             reset_project_if_exists=True,
         )
@@ -153,7 +153,7 @@ def test_map_embedding_progressive():
 
     project = atlas.map_embeddings(
         embeddings=embeddings,
-        map_name='UNITTEST1',
+        name='UNITTEST1',
         id_field='id',
         data=data,
         is_public=True,
@@ -171,7 +171,7 @@ def test_map_embedding_progressive():
         if project.is_accepting_data:
             project = atlas.map_embeddings(
                 embeddings=embeddings,
-                map_name=current_project.name,
+                name=current_project.name,
                 colorable_fields=['upload'],
                 id_field='id',
                 data=data,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 description = 'The offical Nomic python client.'
 setup(
     name='nomic',
-    version='1.0.33',
+    version='1.0.34',
     url='https://github.com/nomic-ai/nomic',
     description=description,
     long_description=description,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 description = 'The offical Nomic python client.'
 setup(
     name='nomic',
-    version='1.0.34',
+    version='1.0.39',
     url='https://github.com/nomic-ai/nomic',
     description=description,
     long_description=description,


### PR DESCRIPTION
YMMV, but I find it confusing to have this argument called `map_name` that turns into `project_name` and `index_name`. Plus the arguments to the `AtlasProject` constructor aren't `project_name` and `project_description`, they're just `name` and `description`. I propose that we do the same thing for `map_embeddings` and `map_text`--makes it easier to switch between the quickstart workflow, avoids adding `map_name` as a nonexistent identifier into our implicit namespace.