### PR TITLE
Ipyframes

### DIFF
--- a/nomic/project.py
+++ b/nomic/project.py
@@ -346,7 +346,7 @@ class AtlasProjection:
     Instead instantiate an AtlasProject and use the project.indices or get_map method to retrieve an AtlasProjection.
     '''
 
-    def __init__(self, project : AtlasProject, atlas_index_id: str, projection_id: str, name):
+    def __init__(self, project : "AtlasProject", atlas_index_id: str, projection_id: str, name):
         """
         Creates an AtlasProjection.
         """
@@ -418,7 +418,7 @@ class AtlasProjection:
             }}
         </style>
         """
-    
+
     def _repr_html_(self):
         return f"""
             <h3>Project: {self.name}</h3>

--- a/nomic/project.py
+++ b/nomic/project.py
@@ -336,6 +336,8 @@ class AtlasIndex:
         self.indexed_field = indexed_field
         self.projections = projections
 
+    def _repr_html_(self):
+        return '<br>'.join([d._repr_html_() for d in self.projections])
 
 class AtlasProjection:
     '''
@@ -344,7 +346,7 @@ class AtlasProjection:
     Instead instantiate an AtlasProject and use the project.indices or get_map method to retrieve an AtlasProjection.
     '''
 
-    def __init__(self, project, atlas_index_id: str, projection_id: str, name):
+    def __init__(self, project : AtlasProject, atlas_index_id: str, projection_id: str, name):
         """
         Creates an AtlasProjection.
         """
@@ -367,6 +369,62 @@ class AtlasProjection:
     def __repr__(self):
         return self.__str__()
 
+    def _iframe(self):
+        return f"""
+        <iframe class="iframe" id="iframe{self.id}" allow="clipboard-read; clipboard-write" src="{self.map_link}">
+        </iframe>
+
+        <style>
+            .iframe {{
+                /* vh can be **very** large in vscode ipynb. */
+                height: min(75vh, 66vw);
+                width: 100%;
+            }}
+        </style>
+        """
+    
+    def _embed_html(self):
+        return f"""<script>
+            destroy = function() {{
+                document.getElementById("iframe{self.id}").remove()
+            }}
+        </script>
+        <h4>Projection ID: {self.self.id}</h4>
+        <div class="actions">
+        <div id="hide" class="action" onclick="destroy()">Hide embedded project</div>
+        <a id="out" class="action" href="{self.map_link}" target="_blank">Explore on atlas.nomic.ai</a>
+        </div>
+        {self._iframe()}
+        <style>
+            .actions {{
+              display: flex;
+              flex-direction: col;
+              gap: 3px;
+              flex-wrap: true;
+            }}
+            .action {{
+              transition: all 500ms ease-in-out;
+            }}
+            .action:hover {{
+              fill: 'gray';
+              cursor: pointer;
+              text-style: underline;
+            }}
+            #hide:hover::after {{
+                content: " x";
+            }}
+            #out:hover::after {{
+                content: " 🔗";
+            }}
+        </style>
+        """
+    
+    def _repr_html_(self):
+        return f"""
+            <h3>Project: {self.name}</h3>
+            {self._embed_html()}
+        """
+    
     def _download_feather(self, dest: str = "tiles"):
         '''
         Downloads the feather tree.

--- a/nomic/project.py
+++ b/nomic/project.py
@@ -406,31 +406,28 @@ class AtlasProjection:
         <h4>Projection ID: {self.id}</h4>
         <div class="actions">
             <div id="hide" class="action" onclick="destroy()">Hide embedded project</div>
-            <div>
-                <a id="out" class="action" href="{self.map_link}" target="_blank">Explore on atlas.nomic.ai</a>
+            <div class="action" id="out">
+                <a href="{self.map_link}" target="_blank">Explore on atlas.nomic.ai</a>
             </div>
         </div>
         {self._iframe()}
         <style>
             .actions {{
-              display: flex;
-              flex-direction: col;
-              gap: 3px;
-              flex-wrap: true;
+              display: block;
             }}
             .action {{
+              min-height: 18px;
+              margin: 5px;
               transition: all 500ms ease-in-out;
             }}
             .action:hover {{
-              fill: 'gray';
               cursor: pointer;
-              text-style: underline;
             }}
             #hide:hover::after {{
-                content: " x";
+                content: " X";
             }}
             #out:hover::after {{
-                content: " 🔗";
+                content: "";
             }}
         </style>
         """
@@ -1107,22 +1104,25 @@ class AtlasProject(AtlasClass):
             <strong><a href="https://atlas.nomic.ai/dashboard/project/{m['id']}">{m['project_name']}</strong></a>
             <br>
             {m['description']} {m['total_datums_in_project']} datums inserted.
-            {len(m['atlas_indices'])} indexes built.
+            <br>
+            {len(m['atlas_indices'])} index built.
             """
         complete_projections = []
         if len(self.projections) >= 1:
-            html += "<strong>Projections</strong> <ul>"
+            html += "<br><strong>Projections</strong>\n"
+            html += "<ul>\n"
             for projection in self.projections:
                 state = projection._status['index_build_stage']
                 if state == 'Completed':
                     complete_projections.append(projection)
-                html += """<li>{projection.name}. Status {state}. <a target="_blank" href="{projection.map_link}">view online</a></li>"""   
+                html += f"""<li>{projection.name}. Status {state}. <a target="_blank" href="{projection.map_link}">view online</a></li>"""   
             html += "</ul>"
         if len(complete_projections) >= 1:
             # Display most recent complete projection.
             html += "<hr>"
             html += complete_projections[-1]._embed_html()
-            
+        return html
+    
     def __str__(self):
         return "\n".join([str(projection) for index in self.indices for projection in index.projections])
 

--- a/nomic/project.py
+++ b/nomic/project.py
@@ -346,6 +346,7 @@ class AtlasProjection:
     Instead instantiate an AtlasProject and use the project.indices or get_map method to retrieve an AtlasProjection.
     '''
 
+
     def __init__(self, project : "AtlasProject", atlas_index_id: str, projection_id: str, name):
         """
         Creates an AtlasProjection.
@@ -362,6 +363,18 @@ class AtlasProjection:
         Retrieves a map link.
         '''
         return f"{self.project.web_path}/map/{self.project.id}/{self.id}"
+
+    @property
+    def _status(self):
+        response = requests.get(
+            self.project.atlas_api_path + f"/v1/project/index/job/progress/{self.atlas_index_id}",
+            headers=self.project.header,
+        )
+        if response.status_code != 200:
+            raise Exception(response.json()['detail'])
+
+        content = response.json()
+        return content
 
     def __str__(self):
         return f"{self.name}: {self.map_link}"
@@ -389,10 +402,13 @@ class AtlasProjection:
                 document.getElementById("iframe{self.id}").remove()
             }}
         </script>
+
         <h4>Projection ID: {self.id}</h4>
         <div class="actions">
-        <div id="hide" class="action" onclick="destroy()">Hide embedded project</div>
-        <a id="out" class="action" href="{self.map_link}" target="_blank">Explore on atlas.nomic.ai</a>
+            <div id="hide" class="action" onclick="destroy()">Hide embedded project</div>
+            <div>
+                <a id="out" class="action" href="{self.map_link}" target="_blank">Explore on atlas.nomic.ai</a>
+            </div>
         </div>
         {self._iframe()}
         <style>
@@ -420,10 +436,14 @@ class AtlasProjection:
         """
 
     def _repr_html_(self):
+        # Don't make an iframe if the project is locked.
+        state = self._status['index_build_stage']
+        if state != 'Completed':
+            return f"""Atlas Projection {self.name}. Status {state}. <a target="_blank" href="{self.map_link}">view online</a>"""
         return f"""
             <h3>Project: {self.name}</h3>
             {self._embed_html()}
-        """
+            """
     
     def _download_feather(self, dest: str = "tiles"):
         '''
@@ -1082,16 +1102,30 @@ class AtlasProject(AtlasClass):
         return f"AtlasProject: <{m}>"
 
     def _repr_html_(self):
+        self._latest_project_state()
         m = self.meta
-        return f"""An Atlas Project.
-            <h3><a href="https://atlas.nomic.ai/dashboard/project/{m['id']}">{m['project_name']}</h3></a>
+        html = f"""
+            <strong><a href="https://atlas.nomic.ai/dashboard/project/{m['id']}">{m['project_name']}</strong></a>
+            <br>
             {m['description']} {m['total_datums_in_project']} datums inserted.
             {len(m['atlas_indices'])} indexes built.
             """
-    
+        complete_projections = []
+        if len(self.projections) >= 1:
+            html += "<strong>Projections</strong> <ul>"
+            for projection in self.projections:
+                state = projection._status['index_build_stage']
+                if state == 'Completed':
+                    complete_projections.append(projection)
+                html += """<li>{projection.name}. Status {state}. <a target="_blank" href="{projection.map_link}">view online</a></li>"""   
+            html += "</ul>"
+        if len(complete_projections) >= 1:
+            # Display most recent complete projection.
+            html += "<hr>"
+            html += complete_projections[-1]._embed_html()
+            
     def __str__(self):
         return "\n".join([str(projection) for index in self.indices for projection in index.projections])
-
 
     def get_data(self, ids: List[str]) -> List[Dict]:
         '''

--- a/nomic/project.py
+++ b/nomic/project.py
@@ -389,7 +389,7 @@ class AtlasProjection:
                 document.getElementById("iframe{self.id}").remove()
             }}
         </script>
-        <h4>Projection ID: {self.self.id}</h4>
+        <h4>Projection ID: {self.id}</h4>
         <div class="actions">
         <div id="hide" class="action" onclick="destroy()">Hide embedded project</div>
         <a id="out" class="action" href="{self.map_link}" target="_blank">Explore on atlas.nomic.ai</a>

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 description = 'The offical Nomic python client.'
 setup(
     name='nomic',
-    version='1.0.33',
+    version='1.0.40',
     url='https://github.com/nomic-ai/nomic',
     description=description,
     long_description=description,


### PR DESCRIPTION
This adds `_repr_html_` to AtlasProject, AtlasProjection, and AtlasIndex classes that includes, frequently, and embedded iframe to the Atlas viewer of the project.

If there's a complete projection build in the project (determined through calling the API projection status endpoint)
it adds the most recent one to the `AtlasProject` display, and it shows it for AtlasProjection. Otherwise, it just gives the status and a link to Atlas.

There's a place to delete the big interactive memory hog if you don't like it.
