### PR TITLE
shorter random identifiers

### DIFF
--- a/nomic/project.py
+++ b/nomic/project.py
@@ -203,7 +203,8 @@ class AtlasClass(object):
                 raise ValueError(msg)
 
         if project.id_field == ATLAS_DEFAULT_ID_FIELD and not ATLAS_DEFAULT_ID_FIELD in data.column_names:
-            data = data.append_column(ATLAS_DEFAULT_ID_FIELD, pa.array([str(uuid.uuid4()) for _ in range(len(data))]))
+            # Generate random ids.
+            data = data.append_column(ATLAS_DEFAULT_ID_FIELD, pa.array([base64.b64encode(uuid.uuid4().bytes[:8]).decode('utf-8').rstrip('=') for _ in range(len(data))]))
 
         if project.schema is None:
             project._schema = convert_pyarrow_schema_for_atlas(data.schema)


### PR DESCRIPTION
I believe that eventually--probably soon--we're going to want to ship datum ids to the browser for everything. One problem with doing that is that UUIDs are really, really long--36 characters. They don't need to be.

A uuid is 128 bits. 64 bits [is plenty to avoid hash collisions](https://kevingal.com/apps/collision.html), so I take half the UUID; and then b64encode it instead of using hex. This means it takes under a third of the space in the browser. There is no downside.