### PR TITLE
allow overriding api path with env var

### DIFF
--- a/nomic/project.py
+++ b/nomic/project.py
@@ -61,6 +61,9 @@ class AtlasClass(object):
 
         self.atlas_api_path = f"https://{api_hostname}"
         self.web_path = f"https://{web_hostname}"
+        override_api_path = os.environ['ATLAS_API_PATH']
+        if override_api_path:
+            self.atlas_api_path = override_api_path
 
         token = self.credentials['token']
         self.token = token


### PR DESCRIPTION
this allows testing against a local atlas dev env (once `nomic login`d as a staging user) with e.g.

```bash
ATLAS_API_PATH=http://localhost make test
```