### PR TITLE
_add_data: remove no-op json param in upload post

### DIFF
--- a/nomic/project.py
+++ b/nomic/project.py
@@ -1638,7 +1638,6 @@ class AtlasProject(AtlasClass):
                     self.atlas_api_path + upload_endpoint,
                     headers=self.header,
                     data = buffer,
-                    json={'project_id': self.id},
                 )
                 return response
 


### PR DESCRIPTION
only one of `data` or `json` are used to construct the request body and
`data` takes precedence, so this is being ignored. it is not expected on
the backend
