### PR TITLE
generate *semirandom* ids when creating ids for data

### DIFF
--- a/nomic/project.py
+++ b/nomic/project.py
@@ -6,7 +6,6 @@ import json
 import os
 import pickle
 import time
-import uuid
 from collections import defaultdict
 from datetime import date, datetime
 from pathlib import Path
@@ -38,7 +37,7 @@ import nomic
 
 from .cli import refresh_bearer_token, validate_api_http_response
 from .settings import *
-from .utils import assert_valid_project_id, get_object_size_in_bytes
+from .utils import assert_valid_project_id, get_object_size_in_bytes, ulid_bytes
 from .data_inference import convert_pyarrow_schema_for_atlas
 from .data_operations import (
     AtlasDuplicates
@@ -216,8 +215,8 @@ class AtlasClass(object):
                 raise ValueError(msg)
 
         if project.id_field == ATLAS_DEFAULT_ID_FIELD and not ATLAS_DEFAULT_ID_FIELD in data.column_names:
-            # Generate random ids.
-            data = data.append_column(ATLAS_DEFAULT_ID_FIELD, pa.array([base64.b64encode(uuid.uuid4().bytes[:8]).decode('utf-8').rstrip('=') for _ in range(len(data))]))
+            # Generate semirandom ids
+            data = data.append_column(ATLAS_DEFAULT_ID_FIELD, pa.array([base64.b64encode(ulid_bytes()).decode('utf-8').rstrip('=') for _ in range(len(data))]))
 
         if project.schema is None:
             project._schema = convert_pyarrow_schema_for_atlas(data.schema)

--- a/nomic/utils.py
+++ b/nomic/utils.py
@@ -1,9 +1,16 @@
 import gc
 import sys
 from uuid import UUID
+import time
+import os
 
 from wonderwords import RandomWord
 
+def ulid_bytes(timebytes=6, randbytes=10):
+    timestamp = int(time.time() * 1000)
+    timebytes = int.to_bytes(timestamp, timebytes, "big")
+    randbytes = os.urandom(randbytes)
+    return timebytes + randbytes
 
 def get_random_name():
     random_words = RandomWord()


### PR DESCRIPTION
use the format of a ULID: https://github.com/ulid/javascript#specification but not the python librar(ies) since there's like 3 of them that all use the module name 'ulid' and I don't want to get broken if the venv we're installed into has a different one than the one I chose

avoids two potential issues

* Birthday problem: 64-bit random IDs as introduced in https://github.com/nomic-ai/nomic/pull/154 are still likely to collide, getting to nearly a 50% probability of collision for each new ID at around ~5B ids which is conceivably a data size we may wany to handle

and more importantly:

* Be nicer to databases that index on this field - in ordered search structures (anything that's not hash-based, such as b-trees often used for database indices) random IDs tend result in worst-case access patterns - this matters most for bulk accesses and inserts, I've illustrated the problem / potential I/O saving of using semirandom IDs in a notebook: https://gist.github.com/apage43/436d3198c48d9a1a20a0c34bd98a527d

However, this bumps the size back up to 128 bits (still keeping the smaller base64 string encoding) - if we want short autogenerated IDs *and* collision avoidance I think we just need to find some way to generate *sequential* IDs (you wouldn't want to do this one at a time, I figure you could expose some method to get the current max ID and start from there, but its important to be careful around potentially introducing a race condition here - with random IDs concurrent inserts just work)
