### PR TITLE
Embedding import

### DIFF
--- a/nomic/project.py
+++ b/nomic/project.py
@@ -205,6 +205,13 @@ class AtlasClass(object):
         if project.id_field not in data.column_names:
             raise ValueError(f'Data must contain the ID column `{project.id_field}`')
 
+        seen = set()
+        for col in data.column_names:
+            if col.lower() in seen:
+                raise ValueError(f'Two different fields have the same lowercased name, `{col}`'
+                ': you must use unique column names.')
+            seen.add(col.lower())
+            
         if project.schema is None:
             project._schema = convert_pyarrow_schema_for_atlas(data.schema)
         # Reformat to match the schema of the project.


### PR DESCRIPTION
Adds an nparray at `Map.embeddings.latent`.

Notes:
* Uses single-threaded download: on contrary wifi, this takes 4 min 19 seconds to download a 1649399 dataset. Could be significantly faster.
* Returns embeddings as `float16`, which some people might find weird.
* Provides a consistent traversal order over data.
* Does not have a tqdm progress bar for the download'
* Wrote a new download method and deprecation-error the old one rather than just overwrite it.
* Does not yet include tests.