### PR TITLE
feat: allow arrow table for upload in map_text

### DIFF
--- a/nomic/atlas.py
+++ b/nomic/atlas.py
@@ -6,6 +6,7 @@ or in a Jupyter Notebook to organize and interact with your unstructured data.
 import uuid
 from typing import Dict, Iterable, List, Optional, Union
 
+import pyarrow as pa
 import numpy as np
 from pandas import DataFrame
 from loguru import logger
@@ -13,7 +14,7 @@ from tqdm import tqdm
 
 from .project import AtlasProject
 from .settings import *
-from .utils import b64int, get_random_name
+from .utils import b64int, get_random_name, arrow_iterator
 
 
 def map_embeddings(
@@ -209,6 +210,9 @@ def map_text(
     if isinstance(data, DataFrame):
         # Convert DataFrame to a generator of dictionaries
         data_iterator = (row._asdict() for row in data.itertuples(index=False))
+    elif isinstance(data, pa.Table):
+        # Create generator from pyarrow table
+        data_iterator = arrow_iterator(data)
     else:
         data_iterator = iter(data)
 

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 import requests
 from nomic import AtlasProject, atlas
+import pyarrow as pa
 import pandas as pd
 
 def gen_random_datetime(min_year=1900, max_year=datetime.now().year):
@@ -403,6 +404,31 @@ def test_map_text_pandas():
     )
 
     map = project.get_map(name='UNITTEST_pandas_text')
+
+    assert project.total_datums == 50
+
+    project.delete()
+
+    
+def test_map_text_arrow():
+    size = 50
+    data = pa.Table.from_pydict({
+        'field': [str(uuid.uuid4()) for i in range(size)],
+        'id': [str(uuid.uuid4()) for i in range(size)],
+        'color': [random.choice(['red', 'blue', 'green']) for i in range(size)],
+    })
+
+    project = atlas.map_text(
+        name='UNITTEST_arrow_text',
+        id_field='id',
+        indexed_field="color",
+        data=data,
+        is_public=True,
+        colorable_fields=['color'],
+        reset_project_if_exists=True,
+    )
+
+    map = project.get_map(name='UNITTEST_arrow_text')
 
     assert project.total_datums == 50
 

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -351,7 +351,12 @@ def test_map_embeddings():
 
     map = project.get_map(name='UNITTEST1')
 
-    time.sleep(10)
+    num_tries = 0
+    while map.project.is_locked:
+        time.sleep(10)
+        num_tries += 1
+        if num_tries > 5:
+            raise TimeoutError('Timed out while waiting for project to unlock')
 
     retrieved_embeddings = map.embeddings.latent
 

--- a/nomic/utils.py
+++ b/nomic/utils.py
@@ -1,10 +1,20 @@
 import base64
 import gc
 import sys
+import pyarrow as pa
 from uuid import UUID
 
 from wonderwords import RandomWord
 
+
+def arrow_iterator(table: pa.Table):
+    # TODO: setting to 10k so it doesn't take too long?
+    # Wrote this as a generator so we don't realize the whole table in memory
+    reader = table.to_reader(max_chunksize=10_000)
+    for batch in reader:
+        for item in batch.to_pylist():
+            yield item
+    
 
 def b64int(i: int):
     ibytes = int.to_bytes(i, length=8, byteorder='big').lstrip(b'\x00')


### PR DESCRIPTION
Previously, this failed as iterating over a pyarrow table iterates over the columns. For example, 

```
import pyarrow as pa

>>> schema = pa.schema([
...     ('text', pa.string()),
...     ('url', pa.string())
... ])
>>> 
>>> # Sample data
>>> data = {
...     'text': ['sample1', 'sample2', 'sample3', 'sample4', 'sample5'],
...     'url': ['http://example1.com', 'http://example2.com', 'http://example3.com', 'http://example4.com', 'http://example5.com']
... }
>>> 
>>> tb = pa.Table.from_pydict(data)
>>> tb
pyarrow.Table
text: string
url: string
----
text: [["sample1","sample2","sample3","sample4","sample5"]]
url: [["http://example1.com","http://example2.com","http://example3.com","http://example4.com","http://example5.com"]]
>>> for x in tb:
...     break
... 
>>> x
<pyarrow.lib.ChunkedArray object at 0x7fc8c663e7c0>
[
  [
    "sample1",
    "sample2",
    "sample3",
    "sample4",
    "sample5"
  ]
]
>>> 
```

when we want to iterate over the rows instead. Feel free to critique my pyarrow code, I just hacked around on this. 