### PR TITLE
16MB Upload Limit and Small Bug Fix on copying first sample

### DIFF
--- a/nomic/atlas.py
+++ b/nomic/atlas.py
@@ -250,6 +250,8 @@ def map_text(
         upload_batch_size = 100_000
         id_to_add = 0
         if add_id_field:
+            # do not modify object the user passed in
+            first_sample = first_sample.copy()
             first_sample[id_field] = b64int(id_to_add)
             id_to_add += 1
         

--- a/nomic/project.py
+++ b/nomic/project.py
@@ -1321,8 +1321,8 @@ class AtlasProject(AtlasClass):
         shard_size = 5_000
         n_chunks = int(np.ceil(nrow / shard_size))
         # Chunk into 16MB pieces. These will probably compress down a bit.
-        if bytesize / n_chunks > 4_000_000:
-            shard_size = int(np.ceil(nrow / (bytesize / 4_000_000)))
+        if bytesize / n_chunks > 16_000_000:
+            shard_size = int(np.ceil(nrow / (bytesize / 16_000_000)))
 
         data = self._validate_and_correct_arrow_upload(
             data=data,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ description = 'The official Nomic python client.'
     
 setup(
     name='nomic',
-    version='2.0.10',
+    version='2.0.11',
     url='https://github.com/nomic-ai/nomic',
     description=description,
     long_description=description,


### PR DESCRIPTION
4MB is too small and ends up launching a lot of workers for atomize/embed. Raise the upload limit here to 16mb.
During upload, the progress bar will stall for a bit in the beginning (because it's gathering a lot more data), then lots of data will be uploaded.

We've done 16mb before but changed it back because we thought it may be too slow, it's the same speed / faster just has longer startup.