### PR TITLE
Progress bar + Increase Upload limit size

### DIFF
--- a/nomic/atlas.py
+++ b/nomic/atlas.py
@@ -250,12 +250,15 @@ def map_text(
         upload_batch_size = 100_000
         id_to_add = 0
         if add_id_field:
+            # do not modify object the user passed in
+            first_sample = first_sample.copy()
             first_sample[id_field] = b64int(id_to_add)
             id_to_add += 1
         
         batch = [first_sample]
 
-        for d in data_iterator:
+        pbar = tqdm(data_iterator)
+        for d in pbar:
             if add_id_field:
                 # do not modify object the user passed in - also ensures IDs are unique if two input datums are the same *object*
                 d = d.copy()
@@ -264,7 +267,7 @@ def map_text(
                 id_to_add += 1
             batch.append(d)
             if len(batch) >= upload_batch_size:
-                project.add_text(batch)
+                project.add_text(batch, pbar=pbar)
                 batch = []
 
         if len(batch) > 0:

--- a/nomic/project.py
+++ b/nomic/project.py
@@ -346,8 +346,15 @@ class AtlasClass(object):
 
         organization_name, organization_id = self._get_organization(organization_name=organization_name)
         return {'organization_id': organization_id, 'organization_name': organization_name}
+    
+    def get_projects_in_organization(self, organization_name=None, organization_id=None) -> Dict:
+        org_name, org_id = self._get_organization(organization_name=organization_name, organization_id=organization_id)
+        response = requests.get(self.atlas_api_path + "v1/organization/" + org_id)
 
-
+        if response.status_code != 200:
+            raise Exception(f"Failed to get projects in organization: {response.text}")
+        return response.json()['results']
+        
 class AtlasIndex:
     """
     An AtlasIndex represents a single view of an Atlas Project at a point in time.
@@ -1321,8 +1328,8 @@ class AtlasProject(AtlasClass):
         shard_size = 5_000
         n_chunks = int(np.ceil(nrow / shard_size))
         # Chunk into 16MB pieces. These will probably compress down a bit.
-        if bytesize / n_chunks > 4_000_000:
-            shard_size = int(np.ceil(nrow / (bytesize / 4_000_000)))
+        if bytesize / n_chunks > 16_000_000:
+            shard_size = int(np.ceil(nrow / (bytesize / 16_000_000)))
 
         data = self._validate_and_correct_arrow_upload(
             data=data,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ description = 'The official Nomic python client.'
     
 setup(
     name='nomic',
-    version='2.0.10',
+    version='2.0.11',
     url='https://github.com/nomic-ai/nomic',
     description=description,
     long_description=description,


### PR DESCRIPTION
Few changes:

1. Single progress bar with total samples if data object has length object else elapsed time bar 
2. Raise upload limit to 16mb so we don't spawn an insane number of workers. During upload, startup will be slow, then a lot more data will be uploaded at once. There should not be major performance slowdowns here. 
3. Small bug fix to prevent modifying a user passed object during first_sample.
