### PR TITLE
[RFR] Topic Refactor 

### DIFF
--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -122,9 +122,6 @@ class AtlasMapTopics:
     topic_depth columns contain the topic id at that depth.
     Topic ids are unique for each depth.
     Corresponding labels can be found in `topics.metadata`.
-    
-    Backwards Compatibility Note:  
-    Before October 2023, topic_depth columns contained the topic label.
 
     === "Accessing Topics Example"
         ``` py

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -119,9 +119,6 @@ class AtlasMapDuplicates:
 class AtlasMapTopics:
     """
     Atlas Topics State
-    topic_depth columns contain the topic id at that depth.
-    Topic ids are unique for each depth.
-    Corresponding labels can be found in `topics.metadata`.
 
     === "Accessing Topics Example"
         ``` py
@@ -133,11 +130,11 @@ class AtlasMapTopics:
         ```
     === "Output"
         ```
-                        id_   topic_depth_1    topic_depth_2    topic_depth_3
-        0     000262a5-2811               4               23               76
-        1     000c453d-ee97               1                5              128
+                        id_      topic_depth_1       topic_depth_2          topic_depth_3
+        0     000262a5-2811  Space exploration      Hurricane Jeanne        Spacecraft Cassini
+        1     000c453d-ee97   English football      Athens 2004 Olympics    bobby rathore
         ...
-        9999  fffcc65c-38dc               7               53               12
+        9999  fffcc65c-38dc  Space exploration      Presidential elections  Blood
         ```
     """
 

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -123,7 +123,7 @@ class AtlasMapTopics:
     Topic ids are unique for each depth.
     Corresponding labels can be found in `topics.metadata`.
     
-    Backwards Compatibility Note: 
+    Backwards Compatibility Note:  
     Before October 2023, topic_depth columns contained the topic label.
 
     === "Accessing Topics Example"
@@ -188,7 +188,7 @@ class AtlasMapTopics:
         Pandas dataframe where each row gives metadata all map topics including:
 
         - topic id
-        - a human readable topic description
+        - a human readable topic description (topic label)
         - identifying keywords that differentiate the topic from other topics
         """
         if self._metadata is not None:

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -259,7 +259,12 @@ class AtlasMapTopics:
                 continue
 
             result_dict = {}
-            topic_metadata = topic_df[(topic_df["topic_id"] == topic) & (topic_df["depth"] == topic_depth)]
+            # New logic
+            if type(topic) == int:
+                topic_metadata = topic_df[(topic_df["topic_id"] == topic) & (topic_df["depth"] == topic_depth)]
+            else:
+                topic_metadata = topic_df[topic_df["topic_short_description"] == topic]
+
             topic_label = topic_metadata["topic_short_description"].item()
             subtopics = []
             if (topic_label, topic_depth) in hierarchy:
@@ -269,7 +274,7 @@ class AtlasMapTopics:
                 "topic_id"
             ].tolist()
             result_dict["topic_id"] = topic_metadata["topic_id"].item()
-            result_dict["topic_short_description"] = topic_metadata["topic_short_description"].item()
+            result_dict["topic_short_description"] = topic_label
             result_dict["topic_long_description"] = topic_metadata["topic_description"].item()
             result_dict["datum_ids"] = datum_ids
             result.append(result_dict)

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -264,7 +264,6 @@ class AtlasMapTopics:
                 continue
 
             result_dict = {}
-            # New logic
             if self.using_topic_ids:
                 topic_metadata = topic_df[(topic_df["topic_id"] == topic) & (topic_df["depth"] == topic_depth)]
             else:

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -145,23 +145,35 @@ class AtlasMapTopics:
         self.projection = projection
         self.project = projection.project
         self.id_field = self.projection.project.id_field
-        # Required for backwards compatibility - we go from topic labels to topic ids.
-        # Rather than doing this in below methods, check once here on load
-        self.using_topic_ids = False
+        self._metadata = None
+        self._hierarchy = None
+
         try:
             self._tb: pa.Table = projection._fetch_tiles()
             topic_fields = [column for column in self._tb.column_names if column.startswith("_topic_depth_")]
-            if 'int' in topic_fields[0]:
-                self.using_topic_ids = True
             self.depth = len(topic_fields)
+            
+            # If using topic ids, fetch topic labels
+            if 'int' in topic_fields[0]:
+                new_topic_fields = []
+                metadata = self.metadata
+                label_df = metadata[["topic_id", "depth", "topic_short_description"]]
+                for d in range(1, self.depth + 1):
+                    column = f"_topic_depth_{d}_int"
+                    topic_ids_to_label = self._tb[column].to_pandas().rename('topic_id')
+                    topic_ids_to_label = label_df[label_df["depth"] == d].merge(topic_ids_to_label, on='topic_id', how='right')
+                    new_column = f"_topic_depth_{d}"
+                    self._tb = self._tb.append_column(new_column, pa.Array.from_pandas(topic_ids_to_label["topic_short_description"]))
+                    new_topic_fields.append(new_column)
+                topic_fields = new_topic_fields
+
             renamed_fields = [f'topic_depth_{i}' for i in range(1, self.depth + 1)]
             self._tb = self._tb.select(
                 [self.id_field] + topic_fields
             ).rename_columns([self.id_field] + renamed_fields)
+
         except pa.lib.ArrowInvalid as e:
             raise ValueError("Topic modeling has not yet been run on this map.")
-        self._metadata = None
-        self._hierarchy = None
 
     @property
     def df(self) -> pandas.DataFrame:
@@ -266,10 +278,7 @@ class AtlasMapTopics:
                 continue
 
             result_dict = {}
-            if self.using_topic_ids:
-                topic_metadata = topic_df[(topic_df["topic_id"] == topic) & (topic_df["depth"] == topic_depth)]
-            else:
-                topic_metadata = topic_df[topic_df["topic_short_description"] == topic]
+            topic_metadata = topic_df[topic_df["topic_short_description"] == topic]
 
             topic_label = topic_metadata["topic_short_description"].item()
             subtopics = []
@@ -315,12 +324,7 @@ class AtlasMapTopics:
             topic_column = f'topic_depth_{depth}'
             topic_counts = merged_tb.group_by(topic_column).aggregate([(self.id_field, "count")]).to_pandas()
             for _, row in topic_counts.iterrows():
-                if self.using_topic_ids:
-                    # fetch topic label
-                    topic = self.metadata[(self.metadata["topic_id"] == row[topic_column]) \
-                                        & (self.metadata["depth"] == depth)]["topic_short_description"].item()
-                else:
-                    topic = row[topic_column]
+                topic = row[topic_column]
                 if topic not in topic_densities:
                     topic_densities[topic] = 0
                 topic_densities[topic] += row[self.id_field + '_count']

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import random
 import tempfile
@@ -162,7 +161,7 @@ def test_topics():
     num_embeddings = 100
     embeddings = np.random.rand(num_embeddings, 10)
     texts = ['foo', 'bar', 'baz', 'bat']
-    dates = [datetime.datetime(2021, 1, 1), datetime.datetime(2022, 1, 1), datetime.datetime(2023, 1, 1)]
+    dates = [datetime(2021, 1, 1), datetime(2022, 1, 1), datetime(2023, 1, 1)]
     data = [
         {'field': str(uuid.uuid4()), 'id': str(uuid.uuid4()), 'upload': 0.0, 'text': texts[i % 4], 'date': dates[i % 3]}
         for i in range(len(embeddings))
@@ -186,8 +185,8 @@ def test_topics():
         assert len(project.maps[0].topics.vector_search_topics(q, depth=1, k=3)['topics']) == 3
         assert isinstance(project.maps[0].topics.group_by_topic(topic_depth=1), list)
 
-        start = datetime.datetime(2019, 1, 1)
-        end = datetime.datetime(2025, 1, 1)
+        start = datetime(2019, 1, 1)
+        end = datetime(2025, 1, 1)
         assert isinstance(project.maps[0].topics.get_topic_density("date", start, end), dict)
 
         project.delete()

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -183,7 +183,8 @@ def test_topics():
 
         q = np.random.random((3, 10))
         assert len(project.maps[0].topics.vector_search_topics(q, depth=1, k=3)['topics']) == 3
-
+        group = project.maps[0].topics.group_by_topic(topic_depth=1)
+        print(group)
         assert isinstance(project.maps[0].topics.group_by_topic(topic_depth=1), list)
 
         project.delete()

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -162,8 +162,9 @@ def test_topics():
     num_embeddings = 100
     embeddings = np.random.rand(num_embeddings, 10)
     texts = ['foo', 'bar', 'baz', 'bat']
+    dates = [datetime.datetime(2021, 1, 1), datetime.datetime(2022, 1, 1), datetime.datetime(2023, 1, 1)]
     data = [
-        {'field': str(uuid.uuid4()), 'id': str(uuid.uuid4()), 'upload': 0.0, 'text': texts[i % 4]}
+        {'field': str(uuid.uuid4()), 'id': str(uuid.uuid4()), 'upload': 0.0, 'text': texts[i % 4], 'date': dates[i % 3]}
         for i in range(len(embeddings))
     ]
 
@@ -184,6 +185,10 @@ def test_topics():
         q = np.random.random((3, 10))
         assert len(project.maps[0].topics.vector_search_topics(q, depth=1, k=3)['topics']) == 3
         assert isinstance(project.maps[0].topics.group_by_topic(topic_depth=1), list)
+
+        start = datetime.datetime(2019, 1, 1)
+        end = datetime.datetime(2025, 1, 1)
+        assert isinstance(project.maps[0].topics.get_topic_density("date", start, end), dict)
 
         project.delete()
 

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -183,8 +183,6 @@ def test_topics():
 
         q = np.random.random((3, 10))
         assert len(project.maps[0].topics.vector_search_topics(q, depth=1, k=3)['topics']) == 3
-        group = project.maps[0].topics.group_by_topic(topic_depth=1)
-        print(group)
         assert isinstance(project.maps[0].topics.group_by_topic(topic_depth=1), list)
 
         project.delete()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ description = 'The official Nomic python client.'
     
 setup(
     name='nomic',
-    version='2.0.11',
+    version='2.0.12',
     url='https://github.com/nomic-ai/nomic',
     description=description,
     long_description=description,


### PR DESCRIPTION
Refactoring topic code to be compatible with new atlas cloud logic.

Implementation is backwards compatible so old maps will load topics correctly. Main change is topic fields contain topic ids that need to be joined with depth to be identifiable. Before this change, we were using the topic labels. Depths are also not guaranteed to be strictly (1, 2, 3).

`get_topic_density` also happens locally now. This requires downloading the time_field project field. Rather than downloading all the data using `AtlasMapData`, we include an optional `fields` parameter to just fetch the desired field.

TODO: one final test with staging lock for new topic code


