### PR TITLE
Ignore ID Column in Downloads [bugfix]

### DIFF
--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -963,6 +963,7 @@ class AtlasMapData:
                 field
                 for field in self.project.project_fields
                 if field not in self._basic_data.column_names and field != "_embeddings"
+                and field != self.project.meta['unique_id_field']
             ]
         else:
             for field in sidecars:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ description = 'The official Nomic python client.'
     
 setup(
     name='nomic',
-    version='2.0.14',
+    version='2.0.15',
     url='https://github.com/nomic-ai/nomic',
     description=description,
     long_description=description,


### PR DESCRIPTION
Ignores the ID column in all to-disk downloads which caused issues on some datasets between Oct 30 and 31st.