### PR TITLE
Cleaned Python client for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ of an AtlasMap.
 # Access your Atlas map
 map = project.maps[0]
 
-# Access a pandas dataframe associating each datum on your map to their topics at each topic depth.
+# Access a pandas DataFrame associating each datum on your map to their topics at each topic depth.
 topic_df = map.topics.df
 
 print(map.topics.df)

--- a/docs/collection_of_maps.md
+++ b/docs/collection_of_maps.md
@@ -1,4 +1,5 @@
 # Collection of Maps
+
 [Twitter](https://atlas.nomic.ai/map/twitter) (5.4 million tweets)
 
 [Stable Diffusion](https://atlas.nomic.ai/map/stablediffusion) (6.4 million images)
@@ -9,9 +10,9 @@
 
 [MNIST Logits](https://atlas.nomic.ai/map/2a222eb6-8f5a-405b-9ab8-f5ab23b71cfd/1dae224b-0284-49f7-b7c9-5f80d9ef8b32)
 
-
 ## GLUE (General Language Understanding Evaluation)
-Created from the GLUE benchmark as uploaded to the [HuggingFace Hub](https://huggingface.co/datasets/glue).
+
+Created from the GLUE benchmark as uploaded to the [Hugging Face Hub](https://huggingface.co/datasets/glue).
 
 [COLA](https://atlas.nomic.ai/map/2d5544f1-124e-4d28-b9de-f7165c000fe0/62fefbab-8c0d-4039-857e-d6f79c475f49) (10,657 datums)
 

--- a/docs/map_your_text.md
+++ b/docs/map_your_text.md
@@ -46,7 +46,7 @@ Nomic integrates with embedding providers such as [co:here](https://cohere.ai/) 
 ### Text maps with a 🤗 Hugging Face model
 
 This code snippet is a complete example of how to make a map with a Hugging Face model.
-[Example Hugging Face Map](https://atlas.nomic.ai/map/60e57e91-c573-4d1f-85ac-2f00f2a075ae/f5bf58cf-f40b-439d-bd0d-d3a4a8b98496)
+[Example Hugging face Map](https://atlas.nomic.ai/map/60e57e91-c573-4d1f-85ac-2f00f2a075ae/f5bf58cf-f40b-439d-bd0d-d3a4a8b98496)
 
 !!! note
 

--- a/docs/map_your_text.md
+++ b/docs/map_your_text.md
@@ -1,9 +1,11 @@
 # Map Your Text
+
 Map your text documents with Atlas using the `map_text` function.
 Atlas will ingest your documents, organize them with state-of-the-art AI and then serve you back an interactive map.
 Any interaction you do with your data (e.g. tagging) can be accessed programmatically with the Atlas Python API.
 
 ## Map text with Atlas
+
 When sending text you should specify an `indexed_field` in the `map_text` function. This lets Atlas know what metadata field to use when building your map.
 
 === "Atlas Embed"
@@ -12,17 +14,17 @@ When sending text you should specify an `indexed_field` in the `map_text` functi
     from nomic import atlas
     import numpy as np
     from datasets import load_dataset
-    
+
     #Make a dataset with the shape [{'col1': 'val', 'col2': 'val', ...}, etc]
     #Tip: if you're working with a pandas dataframe
     #     use pandas.DataFrame.to_dict('records')
 
     dataset = load_dataset('ag_news')['train']
-    
+
     max_documents = 10000
     subset_idxs = np.random.choice(len(dataset), size=max_documents, replace=False).tolist()
     documents = [dataset[i] for i in subset_idxs]
-    
+
     project = atlas.map_text(data=documents,
                               indexed_field='text',
                               name='News 10k Example',
@@ -37,14 +39,14 @@ When sending text you should specify an `indexed_field` in the `map_text` functi
     https://atlas.nomic.ai/map/0642e9a1-12d9-4504-a987-9ca50ecd5327/699afdee-cea0-4805-9c84-12eca6dbebf8
     ```
 
-
 ## Map text with your own models
+
 Nomic integrates with embedding providers such as [co:here](https://cohere.ai/) and [huggingface](https://huggingface.co/models) to help you build maps of text.
 
+### Text maps with a 🤗 Hugging Face model
 
-### Text maps with a 🤗 HuggingFace model
-This code snippet is a complete example of how to make a map with a HuggingFace model.
-[Example Huggingface Map](https://atlas.nomic.ai/map/60e57e91-c573-4d1f-85ac-2f00f2a075ae/f5bf58cf-f40b-439d-bd0d-d3a4a8b98496)
+This code snippet is a complete example of how to make a map with a Hugging Face model.
+[Example Hugging face Map](https://atlas.nomic.ai/map/60e57e91-c573-4d1f-85ac-2f00f2a075ae/f5bf58cf-f40b-439d-bd0d-d3a4a8b98496)
 
 !!! note
 
@@ -52,7 +54,8 @@ This code snippet is a complete example of how to make a map with a HuggingFace 
     ```bash
     pip install datasets transformers torch
     ```
-=== "HuggingFace Example"
+
+=== "Hugging Face Example"
 
     ``` py title="map_with_huggingface.py"
     from nomic import atlas
@@ -60,18 +63,18 @@ This code snippet is a complete example of how to make a map with a HuggingFace 
     import numpy as np
     import torch
     from datasets import load_dataset
-    
+
     #make dataset
     max_documents = 10000
     dataset = load_dataset("sentiment140")['train']
     documents = [dataset[i] for i in np.random.choice(len(dataset), size=max_documents, replace=False).tolist()]
-    
-    
+
+
     model = AutoModel.from_pretrained("prajjwal1/bert-mini")
     tokenizer = AutoTokenizer.from_pretrained("prajjwal1/bert-mini")
-    
+
     embeddings = []
-    
+
     with torch.no_grad():
         batch_size = 10 # lower this if needed
         for i in range(0, len(documents), batch_size):
@@ -79,15 +82,15 @@ This code snippet is a complete example of how to make a map with a HuggingFace 
             encoded_input = tokenizer(batch, return_tensors='pt', padding=True)
             cls_embeddings = model(**encoded_input)['last_hidden_state'][:, 0]
             embeddings.append(cls_embeddings)
-    
+
     embeddings = torch.cat(embeddings).numpy()
-    
+
     response = atlas.map_embeddings(embeddings=embeddings,
                                     data=documents,
                                     colorable_fields=['sentiment'],
                                     name="Huggingface Model Example",
                                     description="An example of building a text map with a huggingface model.")
-    
+
     print(response)
     ```
 
@@ -96,7 +99,6 @@ This code snippet is a complete example of how to make a map with a HuggingFace 
     ``` bash
     https://atlas.nomic.ai/map/60e57e91-c573-4d1f-85ac-2f00f2a075ae/f5bf58cf-f40b-439d-bd0d-d3a4a8b98496
     ```
-
 
 ### Text maps with a Cohere model
 
@@ -122,23 +124,23 @@ Add your Cohere API key to the below example to see how their large language mod
     from datasets import load_dataset
 
     cohere_api_key = ''
-    
+
     dataset = load_dataset("sentiment140")['train']
-    
+
     max_documents = 10000
     subset_idxs = np.random.choice(len(dataset), size=max_documents, replace=False).tolist()
     documents = [dataset[i] for i in subset_idxs]
 
     embedder = CohereEmbedder(cohere_api_key=cohere_api_key)
-    
+
     print(f"Embedding {len(documents)} documents with Cohere API")
     embeddings = embedder.embed(texts=[document['user'] for document in documents],
                                 model='small')
-    
+
     if len(embeddings) != len(documents):
         raise Exception("Embedding job failed")
     print("Embedding job complete.")
-    
+
     response = atlas.map_embeddings(embeddings=np.array(embeddings),
                                     data=documents,
                                     colorable_fields=['sentiment'],

--- a/docs/map_your_text.md
+++ b/docs/map_your_text.md
@@ -16,7 +16,7 @@ When sending text you should specify an `indexed_field` in the `map_text` functi
     from datasets import load_dataset
 
     #Make a dataset with the shape [{'col1': 'val', 'col2': 'val', ...}, etc]
-    #Tip: if you're working with a pandas dataframe
+    #Tip: if you're working with a pandas DataFrame
     #     use pandas.DataFrame.to_dict('records')
 
     dataset = load_dataset('ag_news')['train']

--- a/docs/map_your_text.md
+++ b/docs/map_your_text.md
@@ -46,7 +46,7 @@ Nomic integrates with embedding providers such as [co:here](https://cohere.ai/) 
 ### Text maps with a 🤗 Hugging Face model
 
 This code snippet is a complete example of how to make a map with a Hugging Face model.
-[Example Hugging face Map](https://atlas.nomic.ai/map/60e57e91-c573-4d1f-85ac-2f00f2a075ae/f5bf58cf-f40b-439d-bd0d-d3a4a8b98496)
+[Example Hugging Face Map](https://atlas.nomic.ai/map/60e57e91-c573-4d1f-85ac-2f00f2a075ae/f5bf58cf-f40b-439d-bd0d-d3a4a8b98496)
 
 !!! note
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -36,7 +36,7 @@ Raise correct errors on bad id uploads
 ### New Data validation
 
 1. Uploads are now internally handled as Arrow tables, allowing greater type safety and data throughput.
-2. In addition to passing lists of dicts, you can directly pass pandas dataframes or pyarrow tables to any upload methods.
+2. In addition to passing lists of dicts, you can directly pass pandas DataFrames or pyarrow tables to any upload methods.
 3. Datetime formats are now passed as native python dates or datetimes (or as pandas date or datetime). ISO-formatted strings will no longer be automatically coerced--just pass your own.
 4. Null values are now allowed in any fields except for embeddings and ids. These can be passed either by setting the key to None, omiting a key from a dictionary, or using a pandas null type.
 5. Typechecking is stricter than before, with the aim of raising errors on the client side sooner.

--- a/examples/duplicate_detection.ipynb
+++ b/examples/duplicate_detection.ipynb
@@ -144,7 +144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can access the underlying data as a pandas dataframe using the `df` attribute."
+    "You can access the underlying data as a pandas DataFrame using the `df` attribute."
    ]
   },
   {

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -247,7 +247,7 @@ class AtlasMapTopics:
             end: A datetime object for the window end
 
         Returns:
-            List[{topic: str, count: int}] - A list of {topic, count} dictionaries, sorted from largest count to smallest count.
+            A list of `{topic, count}` dictionaries, sorted from largest count to smallest count.
         '''
         data = AtlasMapData(self.projection, fields=[time_field])
         time_data = data._tb.select([self.id_field, time_field])
@@ -283,7 +283,7 @@ class AtlasMapTopics:
             depth: (Default 3) the topic depth at which you want to search
 
         Returns:
-            A dict mapping {topic: posterior probability} for each query.
+            A dict mapping `{topic: posterior probability}` for each query.
         '''
 
         if queries.ndim != 2:

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -44,7 +44,7 @@ class AtlasMapDuplicates:
     @property
     def df(self) -> pd.DataFrame:
         """
-        Pandas dataframe mapping each data point to its cluster of semantically similar points
+        Pandas DataFrame mapping each data point to its cluster of semantically similar points
         """
         return self.tb.to_pandas()
 
@@ -67,7 +67,7 @@ class AtlasMapDuplicates:
         return dupes.to_pylist()
 
     def __repr__(self) -> str:
-        repr = f"===Atlas Duplicates for ({self.projection})===\n"
+        repr = f"===Atlas Duplicates for ({self.projection})    git push --set-upstream origin docs-clean\n"
         duplicate_count = len(
             self.tb[self.id_field].filter(pc.equal(self.tb['duplicate_class'], 'deletion candidate'))
         )
@@ -118,7 +118,7 @@ class AtlasMapTopics:
     @property
     def df(self) -> pandas.DataFrame:
         """
-        A pandas dataframe associating each datapoint on your map to their topics as each topic depth.
+        A pandas DataFrame associating each datapoint on your map to their topics as each topic depth.
         """
         return self.tb.to_pandas()
 
@@ -134,7 +134,7 @@ class AtlasMapTopics:
     @property
     def metadata(self) -> pandas.DataFrame:
         """
-        Pandas dataframe where each row gives metadata all map topics including:
+        Pandas DataFrame where each row gives metadata all map topics including:
 
         - topic id
         - a human readable topic description (topic label)
@@ -329,7 +329,7 @@ class AtlasMapEmbeddings:
     @property
     def df(self):
         """
-        Pandas dataframe containing information about embeddings of your datapoints.
+        Pandas DataFrame containing information about embeddings of your datapoints.
 
         Includes only the two-dimensional embeddings
         """
@@ -354,7 +354,7 @@ class AtlasMapEmbeddings:
         These are the points you see in your web browser.
 
         Returns:
-            Pandas dataframe mapping your datapoints to their two-dimensional embeddings.
+            Pandas DataFrame mapping your datapoints to their two-dimensional embeddings.
         """
         return self.df
 
@@ -598,7 +598,7 @@ class AtlasMapEmbeddings:
 class AtlasMapTags:
     """
     Atlas Map Tag State. Tags are shared across all maps in your AtlasProject. You can manipulate tags by filtering over
-    the associated pandas dataframe
+    the associated pandas DataFrame
     """
 
     def __init__(self, projection: "AtlasProjection"):
@@ -610,7 +610,7 @@ class AtlasMapTags:
     @property
     def df(self) -> pd.DataFrame:
         """
-        Pandas dataframe mapping each data point to its tags.
+        Pandas DataFrame mapping each data point to its tags.
         """
 
         id_frame = self._tb.to_pandas()
@@ -828,8 +828,8 @@ class AtlasMapData:
     @property
     def df(self) -> pandas.DataFrame:
         """
-        A pandas dataframe associating each datapoint on your map to their metadata.
-        Converting to pandas dataframe may materialize a large amount of data into memory.
+        A pandas DataFrame associating each datapoint on your map to their metadata.
+        Converting to pandas DataFrame may materialize a large amount of data into memory.
         """
         return self._tb.to_pandas()
 

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -25,7 +25,7 @@ from .settings import EMBEDDING_PAGINATION_LIMIT
 
 class AtlasMapDuplicates:
     """
-    Atlas Duplicate Clusters State. Atlas can automatically group embeddings that are sufficiently close into semantic clusters.
+    Atlas Duplicate Clusters State. Atlas automatically groups embeddings that are sufficiently close into semantic clusters.
     You can use these clusters for semantic duplicate detection allowing you to quickly deduplicate
     your data.
     """
@@ -42,7 +42,7 @@ class AtlasMapDuplicates:
     @property
     def df(self) -> pd.DataFrame:
         """
-        Pandas DataFrame mapping each data point to its cluster of semantically similar points
+        Pandas DataFrame mapping each data point to its cluster of semantically similar points.
         """
         return self.tb.to_pandas()
 
@@ -247,7 +247,11 @@ class AtlasMapTopics:
             end: A datetime object for the window end
 
         Returns:
+<<<<<<< HEAD
             A list of `{topic, count}` dictionaries, sorted from largest count to smallest count.
+=======
+            List[{topic: str, count: int}] - A list of {topic, count} dictionaries, sorted from largest count to smallest count.
+>>>>>>> c8ce66b (typos and punctuation in docstrings)
         '''
         data = AtlasMapData(self.projection, fields=[time_field])
         time_data = data._tb.select([self.id_field, time_field])
@@ -283,7 +287,11 @@ class AtlasMapTopics:
             depth: (Default 3) the topic depth at which you want to search
 
         Returns:
+<<<<<<< HEAD
             A dict mapping `{topic: posterior probability}` for each query.
+=======
+            A dict mapping {topic: posterior probability} for each query.
+>>>>>>> c8ce66b (typos and punctuation in docstrings)
         '''
 
         if queries.ndim != 2:
@@ -328,6 +336,7 @@ class AtlasMapEmbeddings:
     def df(self):
         """
 <<<<<<< HEAD
+<<<<<<< HEAD
         Pandas DataFrame containing information about embeddings of your datapoints. 
         
         Includes only the two-dimensional embeddings. 
@@ -336,6 +345,11 @@ class AtlasMapEmbeddings:
 
         Includes only the two-dimensional embeddings
 >>>>>>> 14acbb4 (fix pandas capitalization)
+=======
+        Pandas DataFrame containing information about embeddings of your datapoints. 
+        
+        Includes only the two-dimensional embeddings. 
+>>>>>>> c8ce66b (typos and punctuation in docstrings)
         """
         return self.tb.to_pandas()
 

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -596,7 +596,7 @@ class AtlasMapEmbeddings:
 class AtlasMapTags:
     """
     Atlas Map Tag State. You can manipulate tags by filtering over
-    the associated pandas DataFrame
+    the associated pandas DataFrame.
     """
 
     def __init__(self, projection: "AtlasProjection"):

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -278,7 +278,7 @@ class AtlasMapTopics:
         - Does by datapoint belong to the "Dog" topic or the "Cat" topic.
 
         Args:
-            queries: a 2d numpy array where each row corresponds to a query vector
+            queries: a 2d NumPy array where each row corresponds to a query vector
             k: (Default 32) the number of neighbors to use when estimating the posterior
             depth: (Default 3) the topic depth at which you want to search
 
@@ -362,7 +362,7 @@ class AtlasMapEmbeddings:
         High dimensional embeddings.
 
         Returns:
-            A memmapped numpy array where each row contains the latent embedding of the corresponding datapoint in the same order as `map.embeddings.projected`.
+            A memmapped NumPy array where each row contains the latent embedding of the corresponding datapoint in the same order as `map.embeddings.projected`.
         """
         if self._latent is not None:
             return self._latent
@@ -428,7 +428,7 @@ class AtlasMapEmbeddings:
         You should not specify both queries and ids.
 
         Args:
-            queries: a 2d numpy array where each row corresponds to a query vector
+            queries: a 2d NumPy array where each row corresponds to a query vector
             ids: a list of ids
             k: the number of closest data points (neighbors) to return for each input query/data id
         Returns:
@@ -438,7 +438,7 @@ class AtlasMapEmbeddings:
         '''
 
         if queries is None and ids is None:
-            raise ValueError('You must specify either a list of datum `ids` or numpy array of `queries` but not both.')
+            raise ValueError('You must specify either a list of datum `ids` or NumPy array of `queries` but not both.')
 
         max_k = 128
         max_queries = 256

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -42,7 +42,7 @@ class AtlasMapDuplicates:
     @property
     def df(self) -> pd.DataFrame:
         """
-        Pandas DataFrame mapping each data point to its cluster of semantically similar points.
+        Pandas dataframe mapping each data point to its cluster of semantically similar points
         """
         return self.tb.to_pandas()
 
@@ -595,8 +595,8 @@ class AtlasMapEmbeddings:
 
 class AtlasMapTags:
     """
-    Atlas Map Tag State. You can manipulate tags by filtering over
-    the associated pandas DataFrame.
+    Atlas Map Tag State. Tags are shared across all maps in your AtlasProject. You can manipulate tags by filtering over
+    the associated pandas dataframe
     """
 
     def __init__(self, projection: "AtlasProjection"):
@@ -608,7 +608,11 @@ class AtlasMapTags:
     @property
     def df(self) -> pd.DataFrame:
         """
+<<<<<<< HEAD
         Pandas DataFrame mapping each data point to its tags.
+=======
+        Pandas dataframe mapping each data point to its tags.
+>>>>>>> 60a9580 (get rid of equals signs markdown)
         """
 
         id_frame = self._tb.to_pandas()

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -25,7 +25,7 @@ from .settings import EMBEDDING_PAGINATION_LIMIT
 
 class AtlasMapDuplicates:
     """
-    Atlas Duplicate Clusters State. Atlas automatically groups embeddings that are sufficiently close into semantic clusters.
+    Atlas Duplicate Clusters State. Atlas can automatically group embeddings that are sufficiently close into semantic clusters.
     You can use these clusters for semantic duplicate detection allowing you to quickly deduplicate
     your data.
     """

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -30,27 +30,6 @@ class AtlasMapDuplicates:
     Atlas automatically groups embeddings that are sufficiently close into semantic clusters.
     You can use these clusters for semantic duplicate detection allowing you to quickly deduplicate
     your data.
-
-    === "Accessing Duplicates Example"
-        ``` py
-        from nomic import AtlasProject
-
-        project = AtlasProject(name='My Project')
-        map = project.maps[0]
-        print(map.duplicates)
-        ```
-    === "Output"
-        ```
-        460 deletion candidates in 9540 clusters
-              id_      duplicate_class   cluster_id
-        0      0A            singleton         5178
-        1      0g  retention candidate          271
-        2      0Q            singleton         6672
-        3      0w            singleton         7529
-        4      1A            singleton         1587
-        ...   ...                  ...          ...
-        9999  JZU            singleton         6346
-        ```
     """
 
     def __init__(self, projection: "AtlasProjection"):
@@ -66,26 +45,6 @@ class AtlasMapDuplicates:
     def df(self) -> pd.DataFrame:
         """
         Pandas dataframe mapping each data point to its cluster of semantically similar points
-
-        === "Accessing Duplicates Example"
-            ``` py
-            from nomic import AtlasProject
-
-            project = AtlasProject(name='My Project')
-            map = project.maps[0]
-            print(map.duplicates.df)
-            ```
-        === "Output"
-            ```
-                  id_     _duplicate_class  _cluster_id
-            0      0A            singleton         5178
-            1      0g  retention candidate          271
-            2      0Q            singleton         6672
-            3      0w            singleton         7529
-            4      1A            singleton         1587
-            ...   ...                  ...          ...
-            9999  JZU            singleton         6346
-            ```
         """
         return self.tb.to_pandas()
 
@@ -120,23 +79,6 @@ class AtlasMapDuplicates:
 class AtlasMapTopics:
     """
     Atlas Topics State
-
-    === "Accessing Topics Example"
-        ``` py
-        from nomic import AtlasProject
-
-        project = AtlasProject(name='My Project')
-        map = project.maps[0]
-        print(map.topics)
-        ```
-    === "Output"
-        ```
-                        id_      topic_depth_1       topic_depth_2          topic_depth_3
-        0     000262a5-2811  Space exploration      Hurricane Jeanne        Spacecraft Cassini
-        1     000c453d-ee97   English football      Athens 2004 Olympics    bobby rathore
-        ...
-        9999  fffcc65c-38dc  Space exploration      Presidential elections  Blood
-        ```
     """
 
     def __init__(self, projection: "AtlasProjection"):
@@ -374,52 +316,7 @@ class AtlasMapTopics:
 
 class AtlasMapEmbeddings:
     """
-    Atlas Embeddings State
-
-    Access latent (high-dimensional) and projected (two-dimensional) embeddings of your datapoints.
-
-    ## Two-dimensional projected embeddings
-
-    === "Accessing 2D Embeddings Example"
-        ``` py
-        from nomic import AtlasProject
-
-        project = AtlasProject(name='My Project')
-        map = project.maps[0]
-        print(map.embeddings)
-        ```
-    === "Output"
-        ```
-              id_          x          y
-        0      0A  -6.164423  21.517719
-        1      0g  -6.606402  -5.601104
-        2      0Q  -9.206946   7.448542
-        ...   ...        ...        ...
-        9998  JZQ   2.110881 -12.937058
-        9999  JZU   7.865006  -6.876243
-        ```
-
-    ## High dimensional latent embeddings
-
-
-    === "Accessing Latent Embeddings Example"
-        ``` py
-        from nomic import AtlasProject
-
-        project = AtlasProject(name='My Project')
-        map = project.maps[0]
-        embeddings = map.embeddings.latent
-        print(embeddings.shape)
-        ```
-    === "Output"
-        ```
-        [10000, 384]
-        ```
-
-
-    !!! warning "High dimensional embeddings"
-        High dimensional embeddings are not immediately downloaded when you access the embeddings attribute - you must explicitly call `map.embeddings.latent`. Once downloaded, subsequent calls will reference your downloaded local copy.
-
+    Atlas Embeddings State. Access latent (high-dimensional) and projected (two-dimensional) embeddings of your datapoints.
     """
 
     def __init__(self, projection: "AtlasProjection"):
@@ -700,31 +597,8 @@ class AtlasMapEmbeddings:
 
 class AtlasMapTags:
     """
-    Atlas Map Tag State
-
-    Tags are shared across all maps in your AtlasProject. You can manipulate tags by filtering over
+    Atlas Map Tag State. Tags are shared across all maps in your AtlasProject. You can manipulate tags by filtering over
     the associated pandas dataframe
-
-    === "Accessing Tags Example"
-        ``` py
-        from nomic import AtlasProject
-
-        project = AtlasProject(name='My Project')
-        map = project.maps[0]
-        print(map.tags)
-        ```
-    === "Output"
-        ```
-              id_  oil  search_engines
-        0      0A    0               0
-        1      0g    0               0
-        2      0Q    0               0
-        3      0w    0               0
-        4      1A    1               0
-        ...   ...  ...             ...
-        9998  JZQ    0               0
-        9999  JZU    0               0
-        ```
     """
 
     def __init__(self, projection: "AtlasProjection"):
@@ -737,27 +611,6 @@ class AtlasMapTags:
     def df(self) -> pd.DataFrame:
         """
         Pandas dataframe mapping each data point to its tags.
-
-        === "Accessing Tags Example"
-            ``` py
-            from nomic import AtlasProject
-
-            project = AtlasProject(name='My Project')
-            map = project.maps[0]
-            print(map.tags.df)
-            ```
-        === "Output"
-            ```
-                  id_  oil  search_engines
-            0      0A    0               0
-            1      0g    0               0
-            2      0Q    0               0
-            3      0w    0               0
-            4      1A    1               0
-            ...   ...  ...             ...
-            9998  JZQ    0               0
-            9999  JZU    0               0
-            ```
         """
 
         id_frame = self._tb.to_pandas()
@@ -877,26 +730,8 @@ class AtlasMapTags:
 
 class AtlasMapData:
     """
-    Atlas Map Data (Metadata) State.
-    This is how you can access text and other associated metadata columns
+    Atlas Map Data (Metadata) State. This is how you can access text and other associated metadata columns
     you uploaded with your project.
-
-    === "Accessing Data Example"
-        ``` py
-        from nomic import AtlasProject
-
-        project = AtlasProject(name='My Project')
-        map = project.maps[0]
-        print(map.data)
-        ```
-    === "Output"
-        ```
-                        id_                        text                   title
-        0     000262a5-2811   The Hurricane occurred...        Hurricane Jeanne
-        1     000c453d-ee97    In the football games...    Athens 2004 Olympics
-        ...
-        9999  fffcc65c-38dc  In 2012, the candidates...  Presidential elections
-        ```
     """
 
     def __init__(self, projection: "AtlasProjection", fields=None):

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -25,9 +25,7 @@ from .settings import EMBEDDING_PAGINATION_LIMIT
 
 class AtlasMapDuplicates:
     """
-    Atlas Duplicate Clusters State
-
-    Atlas automatically groups embeddings that are sufficiently close into semantic clusters.
+    Atlas Duplicate Clusters State. Atlas automatically groups embeddings that are sufficiently close into semantic clusters.
     You can use these clusters for semantic duplicate detection allowing you to quickly deduplicate
     your data.
     """
@@ -44,7 +42,7 @@ class AtlasMapDuplicates:
     @property
     def df(self) -> pd.DataFrame:
         """
-        Pandas DataFrame mapping each data point to its cluster of semantically similar points
+        Pandas DataFrame mapping each data point to its cluster of semantically similar points.
         """
         return self.tb.to_pandas()
 
@@ -249,7 +247,7 @@ class AtlasMapTopics:
             end: A datetime object for the window end
 
         Returns:
-            List[{topic: str, count: int}] - A list of {topic, count} dictionaries, sorted from largest count to smallest count
+            List[{topic: str, count: int}] - A list of {topic, count} dictionaries, sorted from largest count to smallest count.
         '''
         data = AtlasMapData(self.projection, fields=[time_field])
         time_data = data._tb.select([self.id_field, time_field])
@@ -285,7 +283,7 @@ class AtlasMapTopics:
             depth: (Default 3) the topic depth at which you want to search
 
         Returns:
-            A dict mapping {topic: posterior probability} for each query
+            A dict mapping {topic: posterior probability} for each query.
         '''
 
         if queries.ndim != 2:
@@ -329,9 +327,9 @@ class AtlasMapEmbeddings:
     @property
     def df(self):
         """
-        Pandas DataFrame containing information about embeddings of your datapoints.
-
-        Includes only the two-dimensional embeddings
+        Pandas DataFrame containing information about embeddings of your datapoints. 
+        
+        Includes only the two-dimensional embeddings. 
         """
         return self.tb.to_pandas()
 
@@ -436,7 +434,7 @@ class AtlasMapEmbeddings:
         Returns:
             A tuple with two elements containing the following information:
                 neighbors: A set of ids corresponding to the nearest neighbors of each query
-                distances: A set of distances between each query and its neighbors
+                distances: A set of distances between each query and its neighbors.
         '''
 
         if queries is None and ids is None:
@@ -631,7 +629,7 @@ class AtlasMapTags:
 
     def get_tags(self) -> Dict[str, List[str]]:
         '''
-        Retrieves back all tags made in the web browser for a specific map
+        Retrieves back all tags made in the web browser for a specific map.
 
         Returns:
             A dictionary mapping data points to tags.
@@ -696,7 +694,7 @@ class AtlasMapTags:
             delete_all: If true, ignores ids parameter and deletes all specified tags from all data points.
 
         Returns:
-            True on success
+            True on success.
 
         '''
         assert isinstance(ids, list), 'datum_ids must be a list of strings'

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -615,7 +615,7 @@ class AtlasMapEmbeddings:
 
 class AtlasMapTags:
     """
-    Atlas Map Tag State. Tags are shared across all maps in your AtlasProject. You can manipulate tags by filtering over
+    Atlas Map Tag State. You can manipulate tags by filtering over
     the associated pandas DataFrame
     """
 

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -247,11 +247,7 @@ class AtlasMapTopics:
             end: A datetime object for the window end
 
         Returns:
-<<<<<<< HEAD
             A list of `{topic, count}` dictionaries, sorted from largest count to smallest count.
-=======
-            List[{topic: str, count: int}] - A list of {topic, count} dictionaries, sorted from largest count to smallest count.
->>>>>>> c8ce66b (typos and punctuation in docstrings)
         '''
         data = AtlasMapData(self.projection, fields=[time_field])
         time_data = data._tb.select([self.id_field, time_field])
@@ -288,10 +284,14 @@ class AtlasMapTopics:
 
         Returns:
 <<<<<<< HEAD
+<<<<<<< HEAD
             A dict mapping `{topic: posterior probability}` for each query.
 =======
             A dict mapping {topic: posterior probability} for each query.
 >>>>>>> c8ce66b (typos and punctuation in docstrings)
+=======
+            A dict mapping `{topic: posterior probability}` for each query.
+>>>>>>> 79d876a (Fixes to bracket escaping)
         '''
 
         if queries.ndim != 2:

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -595,7 +595,7 @@ class AtlasMapEmbeddings:
 
 class AtlasMapTags:
     """
-    Atlas Map Tag State. Tags are shared across all maps in your AtlasProject. You can manipulate tags by filtering over
+    Atlas Map Tag State. You can manipulate tags by filtering over
     the associated pandas DataFrame
     """
 

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -616,7 +616,7 @@ class AtlasMapEmbeddings:
 class AtlasMapTags:
     """
     Atlas Map Tag State. You can manipulate tags by filtering over
-    the associated pandas DataFrame
+    the associated pandas DataFrame.
     """
 
     def __init__(self, projection: "AtlasProjection"):

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -42,7 +42,7 @@ class AtlasMapDuplicates:
     @property
     def df(self) -> pd.DataFrame:
         """
-        Pandas dataframe mapping each data point to its cluster of semantically similar points
+        Pandas DataFrame mapping each data point to its cluster of semantically similar points
         """
         return self.tb.to_pandas()
 
@@ -327,9 +327,15 @@ class AtlasMapEmbeddings:
     @property
     def df(self):
         """
+<<<<<<< HEAD
         Pandas DataFrame containing information about embeddings of your datapoints. 
         
         Includes only the two-dimensional embeddings. 
+=======
+        Pandas DataFrame containing information about embeddings of your datapoints.
+
+        Includes only the two-dimensional embeddings
+>>>>>>> 14acbb4 (fix pandas capitalization)
         """
         return self.tb.to_pandas()
 
@@ -596,7 +602,7 @@ class AtlasMapEmbeddings:
 class AtlasMapTags:
     """
     Atlas Map Tag State. Tags are shared across all maps in your AtlasProject. You can manipulate tags by filtering over
-    the associated pandas dataframe
+    the associated pandas DataFrame
     """
 
     def __init__(self, projection: "AtlasProjection"):
@@ -608,11 +614,7 @@ class AtlasMapTags:
     @property
     def df(self) -> pd.DataFrame:
         """
-<<<<<<< HEAD
         Pandas DataFrame mapping each data point to its tags.
-=======
-        Pandas dataframe mapping each data point to its tags.
->>>>>>> 60a9580 (get rid of equals signs markdown)
         """
 
         id_frame = self._tb.to_pandas()

--- a/nomic/embedders.py
+++ b/nomic/embedders.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 
 
 class CohereEmbedder:
-    '''Embeds text with the Cohere embedding API'''
+    '''Embeds text with the Cohere embedding API.'''
 
     def __init__(self, cohere_api_key: str):
         '''

--- a/nomic/project.py
+++ b/nomic/project.py
@@ -1249,7 +1249,7 @@ class AtlasProject(AtlasClass):
 
         Args:
             data: A pandas DataFrame, list of dictionaries, or pyarrow Table matching the project schema.
-            embeddings: A numpy array of embeddings: each row corresponds to a row in the table.
+            embeddings: A NumPy array of embeddings: each row corresponds to a row in the table.
             pbar: (Optional). A tqdm progress bar to update.
         """
 
@@ -1261,8 +1261,8 @@ class AtlasProject(AtlasClass):
             raise DeprecationWarning("shard_size is deprecated and no longer has any effect")
         if num_workers is not None:
             raise DeprecationWarning("num_workers is deprecated and no longer has any effect")
-        assert type(embeddings) == np.ndarray, "Embeddings must be a numpy array."
-        assert len(embeddings.shape) == 2, "Embeddings must be a 2D numpy array."
+        assert type(embeddings) == np.ndarray, "Embeddings must be a NumPy array."
+        assert len(embeddings.shape) == 2, "Embeddings must be a 2D NumPy array."
         assert len(data) == embeddings.shape[0], "Data and embeddings must have the same number of rows."
         assert len(data) > 0, "Data must have at least one row."
 

--- a/nomic/project.py
+++ b/nomic/project.py
@@ -324,7 +324,7 @@ class AtlasClass(object):
             organization_name: the organization name
 
         Returns:
-            A dictionary containing the project_id, organization_id and organization_name
+            A dictionary containing the project_id, organization_id and organization_name.
 
         '''
 
@@ -588,7 +588,7 @@ class AtlasProjection:
             overwrite: if True then overwrite existing feather files.
 
         Returns:
-            A list containing all quadtiles downloads
+            A list containing all quadtiles downloads.
         '''
 
         self.tile_destination.mkdir(parents=True, exist_ok=True)
@@ -925,7 +925,7 @@ class AtlasProject(AtlasClass):
 
     def get_map(self, name: str = None, atlas_index_id: str = None, projection_id: str = None) -> AtlasProjection:
         '''
-        Retrieves a Map
+        Retrieves a map.
 
         Args:
             name: The name of your map. This defaults to your projects name but can be different if you build multiple maps in your project.
@@ -1170,13 +1170,13 @@ class AtlasProject(AtlasClass):
 
     def get_data(self, ids: List[str]) -> List[Dict]:
         '''
-        Retrieve the contents of the data given ids
+        Retrieve the contents of the data given ids.
 
         Args:
             ids: a list of datum ids
 
         Returns:
-            A list of dictionaries corresponding
+            A list of dictionaries corresponding to the data.
 
         '''
 
@@ -1429,7 +1429,7 @@ class AtlasProject(AtlasClass):
         self, data: List[Dict], embeddings: Optional[np.array] = None, num_workers: int = 10
     ):
         '''
-        Utility method to update a projects maps by adding the given data.
+        Utility method to update a project's maps by adding the given data.
 
         Args:
             data: An [N,] element list of dictionaries containing metadata for each embedding.
@@ -1485,7 +1485,7 @@ class AtlasProject(AtlasClass):
         reflect the additions, deletions or updates you have made to your data until this method is called.
 
         Args:
-            rebuild_topic_models: (Default False) - If true, will create new topic models when updating these indices
+            rebuild_topic_models: (Default False) - If true, will create new topic models when updating these indices.
         '''
 
         response = requests.post(

--- a/nomic/project.py
+++ b/nomic/project.py
@@ -282,7 +282,7 @@ class AtlasClass(object):
 
     def _get_organization(self, organization_name=None, organization_id=None) -> Tuple[str, str]:
         '''
-        Gets an organization by either it's name or id.
+        Gets an organization by either its name or id.
 
         Args:
             organization_name: the name of the organization


### PR DESCRIPTION
- Removed most extraneous markdown elements in the nomic Python client (they were interfering w/ Docusaurus formatting)
- for example, fixing the '===' issue in https://docs-nomic-ai.vercel.app/reference/python/access-duplicates 
- Fixed typos & standardized some punctuation in docstrings