### PR TITLE
[RFR] Download tags

### DIFF
--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -751,7 +751,7 @@ class AtlasMapTags:
         #     tags: A list containing the tags you want to apply to these data points.
 
         # '''
-        raise NotImplementedError("AtlasMapTags.add is not supported.")
+        raise NotImplementedError("AtlasMapTags.add is currently not supported.")
 
     def remove(self, ids: List[str], tags: List[str], delete_all: bool = False) -> bool:
         # '''
@@ -766,7 +766,7 @@ class AtlasMapTags:
         #     True on success.
 
         # '''
-        raise NotImplementedError("AtlasMapTags.remove is not supported.")
+        raise NotImplementedError("AtlasMapTags.remove is currently not supported.")
 
     def __repr__(self) -> str:
         return str(self.df)

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -596,7 +596,7 @@ class AtlasMapTags:
         tbs = []
         all_quads = list(self.projection._tiles_in_order(coords_only=True))
         for quad in tqdm(all_quads):
-            quad_str = os.path.join([str(q) for q in quad])
+            quad_str = os.path.join(*[str(q) for q in quad])
             datum_id_filename = quad_str + "." + "datum_id" + ".feather"
             path = self.projection.tile_destination / Path(datum_id_filename)
             tb = feather.read_table(path, memory_map=True)
@@ -694,7 +694,7 @@ class AtlasMapTags:
         all_quads = list(self.projection._tiles_in_order(coords_only=True))
         ordered_tag_paths = []
         for quad in tqdm(all_quads):
-            quad_str = os.path.join([str(q) for q in quad])
+            quad_str = os.path.join(*[str(q) for q in quad])
             filename = quad_str + "." + f"_tag.{tag_definition_id}" + ".feather"
             path = self.projection.tile_destination / Path(filename)
             download_attempt = 0
@@ -725,7 +725,7 @@ class AtlasMapTags:
         # NOTE: This currently only gets triggered on `df` property
         all_quads = list(self.projection._tiles_in_order(coords_only=True))
         for quad in tqdm(all_quads):
-            quad_str = os.path.join([str(q) for q in quad])
+            quad_str = os.path.join(*[str(q) for q in quad])
             tile = self.projection.tile_destination / Path(quad_str)
             tile_dir = tile.parent
             if tile_dir.exists():
@@ -840,7 +840,7 @@ class AtlasMapData:
 
         for quad in tqdm(all_quads):
             for sidecar in sidecars:
-                quad_str = os.path.join([str(q) for q in quad])
+                quad_str = os.path.join(*[str(q) for q in quad])
                 encoded_colname = base64.urlsafe_b64encode(sidecar.encode("utf-8")).decode("utf-8")
                 filename = quad_str + "." + encoded_colname + ".feather"
                 path = self.projection.tile_destination / Path(filename)

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -21,7 +21,7 @@ from pyarrow import feather, ipc
 from tqdm import tqdm
 
 from .settings import EMBEDDING_PAGINATION_LIMIT
-from utils import download_file
+from .utils import download_file
 
 
 class AtlasMapDuplicates:

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -669,10 +669,6 @@ class AtlasMapTags:
                 # filter on rows
                 pass
 
-            
-
-
-
     def get_tags(self) -> Dict[str, List[str]]:
         '''
         Retrieves back all tags made in the web browser for a specific map.
@@ -680,24 +676,7 @@ class AtlasMapTags:
         Returns:
             A dictionary mapping data points to tags.
         '''
-        # now get the tags
-        datums_and_tags = requests.post(
-            self.dataset.atlas_api_path + '/v1/project/tag/read/all_by_datum',
-            headers=self.dataset.header,
-            json={
-                'project_id': self.dataset.id,
-            },
-        )
-
-        datums_and_tags = datums_and_tags.json()['results']
-
-        label_to_datums = {}
-        for item in datums_and_tags:
-            for label in item['labels']:
-                if label not in label_to_datums:
-                    label_to_datums[label] = set()
-                label_to_datums[label].add(item['datum_id'])
-        return label_to_datums
+        raise DeprecationWarning("Deprecated as of January 2024. Use `tags` property instead")
 
     def add(self, ids: List[str], tags: List[str]):
         '''
@@ -708,29 +687,7 @@ class AtlasMapTags:
             tags: A list containing the tags you want to apply to these data points.
 
         '''
-        assert isinstance(ids, list), 'ids must be a list of strings'
-        assert isinstance(tags, list), 'tags must be a list of strings'
-
-        colname = json.dumps(
-            {
-                'project_id': self.dataset.id,
-                'atlas_index_id': self.projection.atlas_index_id,
-                'type': 'datum_id',
-                'tags': tags,
-            }
-        )
-        payload_table = pa.table([pa.array(ids, type=pa.string())], [colname])
-        buffer = io.BytesIO()
-        writer = ipc.new_file(buffer, payload_table.schema, options=ipc.IpcWriteOptions(compression='zstd'))
-        writer.write_table(payload_table)
-        writer.close()
-        payload = buffer.getvalue()
-
-        headers = self.dataset.header.copy()
-        headers['Content-Type'] = 'application/octet-stream'
-        response = requests.post(self.dataset.atlas_api_path + "/v1/project/tag/add", headers=headers, data=payload)
-        if response.status_code != 200:
-            raise Exception("Failed to add tags")
+        raise NotImplementedError("AtlasMapTags.add is not implemented.")
 
     def remove(self, ids: List[str], tags: List[str], delete_all: bool = False) -> bool:
         '''
@@ -745,30 +702,7 @@ class AtlasMapTags:
             True on success.
 
         '''
-        assert isinstance(ids, list), 'datum_ids must be a list of strings'
-        assert isinstance(tags, list), 'tags must be a list of strings'
-
-        colname = json.dumps(
-            {
-                'project_id': self.dataset.id,
-                'atlas_index_id': self.projection.atlas_index_id,
-                'type': 'datum_id',
-                'tags': tags,
-                'delete_all': delete_all,
-            }
-        )
-        payload_table = pa.table([pa.array(ids, type=pa.string())], [colname])
-        buffer = io.BytesIO()
-        writer = ipc.new_file(buffer, payload_table.schema, options=ipc.IpcWriteOptions(compression='zstd'))
-        writer.write_table(payload_table)
-        writer.close()
-        payload = buffer.getvalue()
-
-        headers = self.dataset.header.copy()
-        headers['Content-Type'] = 'application/octet-stream'
-        response = requests.post(self.dataset.atlas_api_path + "/v1/project/tag/delete", headers=headers, data=payload)
-        if response.status_code != 200:
-            raise Exception("Failed to delete tags")
+        raise NotImplementedError("AtlasMapTags.remove is not implemented.")
 
     def __repr__(self) -> str:
         return str(self.df)

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -596,7 +596,7 @@ class AtlasMapTags:
         tbs = []
         all_quads = list(self.projection._tiles_in_order(coords_only=True))
         for quad in tqdm(all_quads):
-            quad_str = "/".join([str(q) for q in quad])
+            quad_str = os.path.join([str(q) for q in quad])
             datum_id_filename = quad_str + "." + "datum_id" + ".feather"
             path = self.projection.tile_destination / Path(datum_id_filename)
             tb = feather.read_table(path, memory_map=True)
@@ -694,7 +694,7 @@ class AtlasMapTags:
         all_quads = list(self.projection._tiles_in_order(coords_only=True))
         ordered_tag_paths = []
         for quad in tqdm(all_quads):
-            quad_str = "/".join([str(q) for q in quad])
+            quad_str = os.path.join([str(q) for q in quad])
             filename = quad_str + "." + f"_tag.{tag_definition_id}" + ".feather"
             path = self.projection.tile_destination / Path(filename)
             download_attempt = 0
@@ -725,7 +725,7 @@ class AtlasMapTags:
         # NOTE: This currently only gets triggered on `df` property
         all_quads = list(self.projection._tiles_in_order(coords_only=True))
         for quad in tqdm(all_quads):
-            quad_str = "/".join([str(q) for q in quad])
+            quad_str = os.path.join([str(q) for q in quad])
             tile = self.projection.tile_destination / Path(quad_str)
             tile_dir = tile.parent
             if tile_dir.exists():
@@ -840,7 +840,7 @@ class AtlasMapData:
 
         for quad in tqdm(all_quads):
             for sidecar in sidecars:
-                quad_str = "/".join([str(q) for q in quad])
+                quad_str = os.path.join([str(q) for q in quad])
                 encoded_colname = base64.urlsafe_b64encode(sidecar.encode("utf-8")).decode("utf-8")
                 filename = quad_str + "." + encoded_colname + ".feather"
                 path = self.projection.tile_destination / Path(filename)

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -667,7 +667,12 @@ class AtlasMapTags:
                     datum_ids.extend(tile_tb[self.id_field].to_pylist())
             else:
                 # filter on rows
-                pass
+                try:
+                    tb = tb.append_column(self.id_field, tile_tb[self.id_field])
+                    datum_ids.extend(tb.filter(pc.field("bitmask") == True)[self.id_field].to_pylist())
+                except Exception as e:
+                    raise Exception(f"Failed to fetch datums in tag. {e}")
+        return datum_ids
 
     def get_tags(self) -> Dict[str, List[str]]:
         '''

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -583,7 +583,7 @@ class AtlasMapTags:
         self.auto_cleanup = auto_cleanup
 
     @property
-    def df(self) -> pd.DataFrame:
+    def df(self, overwrite: Optional[bool]=False) -> pd.DataFrame:
         '''
         Pandas DataFrame mapping each data point to its tags.
         '''
@@ -592,7 +592,7 @@ class AtlasMapTags:
         if self.auto_cleanup:
             self._remove_outdated_tag_files(tag_definition_ids)
         for tag in tags:
-            self._download_tag(tag["tag_name"])
+            self._download_tag(tag["tag_name"], overwrite=overwrite)
         tbs = []
         all_quads = list(self.projection._tiles_in_order(coords_only=True))
         for quad in tqdm(all_quads):
@@ -608,9 +608,9 @@ class AtlasMapTags:
                 bitmask = None
                 if "all_set" in tag_tb.column_names:
                     if tag_tb["all_set"][0].as_py() == True:
-                        bitmask = pa.BooleanArray([True] * len(tb))
+                        bitmask = pa.array([True] * len(tb), type=pa.bool_())
                     else:
-                        bitmask = pa.BooleanArray([False] * len(tb))
+                        bitmask = pa.array([False] * len(tb), type=pa.bool_())
                 else:
                     bitmask = tag_tb["bitmask"]
                 tb = tb.append_column(tag["tag_name"], bitmask)

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -658,7 +658,14 @@ class AtlasProjection:
                 path.parent.mkdir(parents=True, exist_ok=True)
                 feather.write_feather(tb, path)
 
-            schema = ipc.open_file(path).schema
+            try:
+                schema = ipc.open_file(path).schema
+            except pa.ArrowInvalid: # <- I think that's it?
+                # Remove the file, put the quad identifier on top of the list, and try again.
+                path.unlink()
+                quad.insert(0, rawquad)
+                continue
+                
             if sidecars is None and b'sidecars' in schema.metadata:
                 # Grab just the filenames
                 sidecars = set([v for k, v in json.loads(schema.metadata.get(b'sidecars')).items()])

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -7,7 +7,7 @@ import os
 import pickle
 import time
 import uuid
-from collections import defaultdict, deque
+from collections import defaultdict
 from contextlib import contextmanager
 from datetime import date, datetime
 from pathlib import Path
@@ -633,13 +633,13 @@ class AtlasProjection:
             A list containing all quadtiles downloads.
         '''
         # TODO: change overwrite default to False once updating projection is removed.
-        quads = deque([f'0/0/0'])
+        quads = [f'0/0/0']
         self.tile_destination.mkdir(parents=True, exist_ok=True)
         root = f'{self.dataset.atlas_api_path}/v1/project/{self.dataset.id}/index/projection/{self.id}/quadtree/'
         all_quads = []
         sidecars = None
         while len(quads) > 0:
-            rawquad = quads.popleft()
+            rawquad = quads.pop(0)
             quad = rawquad + ".feather"
             all_quads.append(quad)
             path = self.tile_destination / quad

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -643,15 +643,15 @@ class AtlasProjection:
             quad = rawquad + ".feather"
             all_quads.append(quad)
             path = self.tile_destination / quad
-            should_redownload = False
-            if path.exists():
+            should_download = False
+            if path.exists() and not overwrite:
                 try:
                     feather.read_table(path, memory_map=True)
                 except pa.lib.ArrowInvalid:
-                    should_redownload = True
+                    should_download = True
 
-            if not path.exists() or overwrite or should_redownload:
-                data = requests.get(root + quad, headers=self.project.header)
+            if not path.exists() or overwrite or should_download:
+                data = requests.get(root + quad)
                 readable = io.BytesIO(data.content)
                 readable.seek(0)
                 tb = feather.read_table(readable, memory_map=True)

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -415,11 +415,11 @@ class AtlasProjection:
     Instead instantiate an AtlasDataset and use the dataset.maps attribute to retrieve an AtlasProjection.
     '''
 
-    def __init__(self, project: "AtlasDataset", atlas_index_id: str, projection_id: str, name):
+    def __init__(self, dataset: "AtlasDataset", atlas_index_id: str, projection_id: str, name):
         """
         Creates an AtlasProjection.
         """
-        self.project = project
+        self.dataset = dataset
         self.id = projection_id
         self.atlas_index_id = atlas_index_id
         self.projection_id = projection_id
@@ -436,13 +436,14 @@ class AtlasProjection:
         '''
         Retrieves a map link.
         '''
-        return f"{self.project.web_path}/data/{self.project.meta['organization_slug']}/{self.project.meta['slug']}/map"
+        return f"{self.dataset.web_path}/data/{self.dataset.meta['organization_slug']}/{self.dataset.meta['slug']}/map"
+        #return f"{self.project.web_path}/data/{self.project.meta['organization_slug']}/{self.project.meta['slug']}/map"
 
     @property
     def _status(self):
         response = requests.get(
-            self.project.atlas_api_path + f"/v1/project/index/job/progress/{self.atlas_index_id}",
-            headers=self.project.header,
+            self.dataset.atlas_api_path + f"/v1/project/index/job/progress/{self.atlas_index_id}",
+            headers=self.dataset.header,
         )
         if response.status_code != 200:
             raise Exception(response.text)
@@ -517,7 +518,7 @@ class AtlasProjection:
     @property
     def duplicates(self):
         """Duplicate detection state"""
-        if self.project.is_locked:
+        if self.dataset.is_locked:
             raise Exception('Dataset is locked! Please wait until the dataset is unlocked to access duplicates.')
         if self._duplicates is None:
             self._duplicates = AtlasMapDuplicates(self)
@@ -526,10 +527,8 @@ class AtlasProjection:
     @property
     def topics(self):
         """Topic state"""
-        if self.project.is_locked:
-            raise Exception(
-                'Dataset is locked for state access! Please wait until the dataset is unlocked to access topics.'
-            )
+        if self.dataset.is_locked:
+            raise Exception('Dataset is locked for state access! Please wait until the dataset is unlocked to access topics.')
         if self._topics is None:
             self._topics = AtlasMapTopics(self)
         return self._topics
@@ -537,10 +536,8 @@ class AtlasProjection:
     @property
     def embeddings(self):
         """Embedding state"""
-        if self.project.is_locked:
-            raise Exception(
-                'Dataset is locked for state access! Please wait until the dataset is unlocked to access embeddings.'
-            )
+        if self.dataset.is_locked:
+            raise Exception('Dataset is locked for state access! Please wait until the dataset is unlocked to access embeddings.')
         if self._embeddings is None:
             self._embeddings = AtlasMapEmbeddings(self)
         return self._embeddings
@@ -548,10 +545,8 @@ class AtlasProjection:
     @property
     def tags(self):
         """Tag state"""
-        if self.project.is_locked:
-            raise Exception(
-                'Dataset is locked for state access! Please wait until the dataset is unlocked to access tags.'
-            )
+        if self.dataset.is_locked:
+            raise Exception('Dataset is locked for state access! Please wait until the dataset is unlocked to access tags.')
         if self._tags is None:
             self._tags = AtlasMapTags(self)
         return self._tags
@@ -559,10 +554,8 @@ class AtlasProjection:
     @property
     def data(self):
         """Metadata state"""
-        if self.project.is_locked:
-            raise Exception(
-                'Dataset is locked for state access! Please wait until the dataset is unlocked to access data.'
-            )
+        if self.dataset.is_locked:
+            raise Exception('Dataset is locked for state access! Please wait until the dataset is unlocked to access data.')
         if self._data is None:
             self._data = AtlasMapData(self)
         return self._data
@@ -641,7 +634,7 @@ class AtlasProjection:
         '''
 
         self.tile_destination.mkdir(parents=True, exist_ok=True)
-        root = f'{self.project.atlas_api_path}/v1/project/{self.project.id}/index/projection/{self.id}/quadtree/'
+        root = f'{self.dataset.atlas_api_path}/v1/project/{self.dataset.id}/index/projection/{self.id}/quadtree/'
         quads = [f'0/0/0']
         all_quads = []
         sidecars = None
@@ -677,7 +670,7 @@ class AtlasProjection:
 
     @property
     def datum_id_field(self):
-        return self.project.meta["unique_id_field"]
+        return self.dataset.meta["unique_id_field"]
 
     def _get_atoms(self, ids: List[str]) -> List[Dict]:
         '''
@@ -695,9 +688,9 @@ class AtlasProjection:
             raise ValueError("You must specify a list of ids when getting data.")
 
         response = requests.post(
-            self.project.atlas_api_path + "/v1/project/atoms/get",
-            headers=self.project.header,
-            json={'project_id': self.project.id, 'index_id': self.atlas_index_id, 'atom_ids': ids},
+            self.dataset.atlas_api_path + "/v1/project/atoms/get",
+            headers=self.dataset.header,
+            json={'project_id': self.dataset.id, 'index_id': self.atlas_index_id, 'atom_ids': ids},
         )
 
         if response.status_code == 200:
@@ -878,7 +871,7 @@ class AtlasDataset(AtlasClass):
             projections = []
             for projection in index['projections']:
                 projection = AtlasProjection(
-                    project=self, projection_id=projection['id'], atlas_index_id=index['id'], name=index['index_name']
+                    dataset=self, projection_id=projection['id'], atlas_index_id=index['id'], name=index['index_name']
                 )
                 projections.append(projection)
             index = AtlasIndex(

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -650,7 +650,7 @@ class AtlasProjection:
             while download_attempt < 3 and not download_success:
                 download_attempt += 1
                 if not path.exists() or overwrite:
-                    data = requests.get(root + quad)
+                    data = requests.get(root + quad, headers=self.dataset.header)
                     readable = io.BytesIO(data.content)
                     readable.seek(0)
                     tb = feather.read_table(readable, memory_map=True)

--- a/nomic/pl_callbacks/pl_callback.py
+++ b/nomic/pl_callbacks/pl_callback.py
@@ -78,7 +78,7 @@ class AtlasEmbeddingExplorer(Callback):
         self.description = description
         self.is_public = is_public
         self.overwrite = overwrite_on_validation
-        self.project = None
+        self.dataset = None
         self.map = None
         self.atlas = AtlasLightningContainer()
         self.rebuild_time_delay = rebuild_time_delay
@@ -165,6 +165,6 @@ class AtlasEmbeddingExplorer(Callback):
             logger.info(e)
             logger.info("Failed to update your map on this validation epoch.")
             return
-        self.project = project
+        self.dataset = project
         self.map = project.maps[0]
         self.last_rebuild_timestamp = datetime.now()

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -180,6 +180,7 @@ def test_topics():
 def test_tagging_private():
     dataset = AtlasDataset("wine-test-private")
     map = dataset.maps[0]
+    print(map.tags.get_tags())
     datum_ids = map.tags.get_datums_in_tag("chardonnay")
     assert len(datum_ids) > 0
     tag_df = map.tags.df

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -118,6 +118,7 @@ def test_date_metadata():
             data=data,
             is_public=True,
         )
+        dataset.delete()
 
 
 def test_dataset_with_updates():

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -180,7 +180,6 @@ def test_topics():
 def test_tagging_private():
     dataset = AtlasDataset("wine-test-private")
     map = dataset.maps[0]
-    print(map.tags.get_tags())
     datum_ids = map.tags.get_datums_in_tag("chardonnay")
     assert len(datum_ids) > 0
     tag_df = map.tags.df

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -323,7 +323,7 @@ def test_map_embeddings():
     map = dataset.maps[0]
 
     num_tries = 0
-    while map.project.is_locked:
+    while map.dataset.is_locked:
         time.sleep(10)
         num_tries += 1
         if num_tries > 5:

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -184,7 +184,7 @@ def test_tagging_private():
     datum_ids = map.tags.get_datums_in_tag("chardonnay")
     assert len(datum_ids) > 0
     tag_df = map.tags.df
-    assert len(tag_df.columns) == 4
+    assert len(tag_df.columns) == 2
 
 
 def test_data():

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -180,7 +180,7 @@ def test_topics():
 def test_tagging_private():
     dataset = AtlasDataset("wine-test-private")
     map = dataset.maps[0]
-    datum_ids = map.tags.get_datums_in_tag("oak")
+    datum_ids = map.tags.get_datums_in_tag("chardonnay")
     assert len(datum_ids) > 0
     tag_df = map.tags.df
     assert len(tag_df.columns) == 4

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -174,11 +174,16 @@ def test_topics():
         assert len(dataset.maps[0].topics.vector_search_topics(q, depth=1, k=3)['topics']) == 3
         assert isinstance(dataset.maps[0].topics.group_by_topic(topic_depth=1), list)
 
-        # start = datetime(2019, 1, 1)
-        # end = datetime(2025, 1, 1)
-        # assert isinstance(dataset.maps[0].topics.get_topic_density("date", start, end), dict)
-
         dataset.delete()
+
+
+def test_tagging_private():
+    dataset = AtlasDataset("wine-test-private")
+    map = dataset.maps[0]
+    datum_ids = map.tags.get_datums_in_tag("oak")
+    assert len(datum_ids) > 0
+    tag_df = map.tags.df
+    assert len(tag_df.columns) == 4
 
 
 def test_data():

--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -347,14 +347,6 @@ def test_map_embeddings():
     for map in dataset.projections:
         assert map.map_link
 
-    map.tags.add(ids=[data[0]['id']], tags=['my_tag'])
-
-    assert len(map.tags.get_tags()['my_tag']) == 1
-
-    map.tags.remove(ids=[data[0]['id']], tags=['my_tag'])
-
-    assert 'my_tag' not in map.tags.get_tags()
-
     dataset.delete()
 
 

--- a/nomic/utils.py
+++ b/nomic/utils.py
@@ -9,7 +9,7 @@ import requests
 import pyarrow as pa
 from uuid import UUID
 
-import pyarrow as pa, feather
+import pyarrow as pa
 
 nouns = [
     'newton',
@@ -245,6 +245,6 @@ def download_feather(url: str, path: str, headers: Optional[dict] = None):
     data = requests.get(url, headers=headers)
     readable = BytesIO(data.content)
     readable.seek(0)
-    tb = feather.read_table(readable, memory_map=True)
+    tb = pa.feather.read_table(readable, memory_map=True)
     path.parent.mkdir(parents=True, exist_ok=True)
-    feather.write_feather(tb, path)
+    pa.feather.write_feather(tb, path)

--- a/nomic/utils.py
+++ b/nomic/utils.py
@@ -2,6 +2,9 @@ import base64
 import gc
 import random
 import sys
+
+import requests
+import pyarrow as pa
 from uuid import UUID
 
 import pyarrow as pa
@@ -233,3 +236,12 @@ def get_object_size_in_bytes(obj):
         marked.update(new_refr.keys())
 
     return sz
+
+# Helpful function for downloading feather files
+def download_file(url: str, path: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with requests.get(url, stream=True) as response:
+        response.raise_for_status()
+        with open(path, 'wb') as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)

--- a/nomic/utils.py
+++ b/nomic/utils.py
@@ -238,7 +238,7 @@ def get_object_size_in_bytes(obj):
     return sz
 
 # Helpful function for downloading feather files
-def download_file(url: str, path: str):
+def download_feather(url: str, path: str):
     path.parent.mkdir(parents=True, exist_ok=True)
     with requests.get(url, stream=True) as response:
         response.raise_for_status()


### PR DESCRIPTION
This PR updates AtlasMapTags to match the new atlas_cloud implementation.

Code changes include:
- Fetching completed tags
- Downloading bitmasks for tags
- Returning datum_ids associated with a tag
- Returning a single dataframe with all tags for each datum_id
- Deprecation: removes adding or removing tags using Python client


note:
I started renaming mentions of self.project to self.dataset for consistency. May not be appropriate place to do it and will remove if so