### PR TITLE
v2.x hotfix for enteprise auth without cli

### DIFF
--- a/nomic/cli.py
+++ b/nomic/cli.py
@@ -34,7 +34,12 @@ def get_api_credentials(fn=None):
         return credentials
 
 
-def login(token, tenant='production'):
+def login(token, tenant='production', domain=None):
+    if tenant == 'enterprise':
+        if domain is not None:
+            tenants['enterprise'] = { 'frontend_domain': domain, 'api_domain': f'api.{domain}' }
+        else:
+            raise ValueError('Must pass `domain` to log into an enteprise environment')
     environment = tenants[tenant]
     auth0_auth_endpoint = f"https://{environment['frontend_domain']}/cli-login"
 
@@ -116,8 +121,6 @@ def switch(tenant):
 @click.argument('command', nargs=1, default='')
 @click.argument('params', nargs=-1)
 def cli(command, params, domain=None):
-    if domain is not None:
-        tenants['enterprise'] = { 'frontend_domain': domain, 'api_domain': f'api.{domain}' }
     if command == 'login':
         if len(params) == 0:
             login(token=None, tenant='production')
@@ -128,11 +131,11 @@ def cli(command, params, domain=None):
         if len(params) == 1 and params[0] == 'enterprise':
             if domain is None:
                 raise ValueError('Must pass --domain to log into an enterprise environment')
-            login(token=None, tenant='enterprise')
+            login(token=None, tenant='enterprise', domain=domain)
         if len(params) == 2 and params[0] == 'enterprise':
             if domain is None:
                 raise ValueError('Must pass --domain to log into an enterprise environment')
-            login(token=params[1], tenant='enterprise')
+            login(token=params[1], tenant='enterprise', domain=domain)
         if len(params) == 1:
             login(token=params[0], tenant='production')
     elif command == 'switch':

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ description = 'The official Nomic python client.'
     
 setup(
     name='nomic',
-    version='2.0.16',
+    version='2.0.17',
     url='https://github.com/nomic-ai/nomic',
     description=description,
     long_description=description,


### PR DESCRIPTION
note this is not a PR to main, but to a `v2.x` branch I just created from the 2.0.16 "version bump" commit

- fix login() for enterprise
- version bump (2.0.17)
