### PR TITLE
fix: dataset sidecar download - datum id sidecars are special

### DIFF
--- a/nomic/tests/test_atlas_client.py
+++ b/nomic/tests/test_atlas_client.py
@@ -197,6 +197,7 @@ def test_data():
         {'field': str(uuid.uuid4()), 'id': str(uuid.uuid4()), 'upload': 0.0, 'text': str(i)}
         for i in range(len(embeddings))
     ]
+    all_columns = data[0].keys()
 
     dataset = atlas.map_data(
         embeddings=embeddings,
@@ -210,7 +211,9 @@ def test_data():
     with dataset.wait_for_dataset_lock():
         df = dataset.maps[0].data.df
         assert len(df) > 0
-        assert "text" in df.columns
+        # all uploaded columns, including the id column, should be in the downloaded data
+        for column in all_columns:
+            assert column in df.columns
         dataset.delete()
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ description = 'The official Nomic python client.'
     
 setup(
     name='nomic',
-    version='3.0.21',
+    version='3.0.22',
     url='https://github.com/nomic-ai/nomic',
     description=description,
     long_description=description,


### PR DESCRIPTION
Downloads the id column when fetching map data, it got lost once sidecars stopped being registered on the root tile - the id column is _special_, it isn't considered part of the "dataset columns" and is always stored as a sidecar named "`datum_id`", _not_ base64'd like user supplied columns (with the original column name in the underlying arrow file) - we still want it here since it is a user supplied column

Fixes NOM-1294
