### PR TITLE
embed: implement inference_mode=dynamic for embed.text

### DIFF
--- a/nomic/embed.py
+++ b/nomic/embed.py
@@ -242,9 +242,6 @@ def _text_embed4all(
     except KeyError:
         raise ValueError(f"Unsupported model for local embeddings: {model!r}") from None
 
-    if any(text == "" for text in texts):
-        raise NotImplementedError("Embedding an empty text is not implemented")
-
     if not texts:
         # special-case this since Embed4All doesn't allow it
         return {"embeddings": [], "usage": {}, "model": model, "inference_mode": "local"}

--- a/nomic/embed.py
+++ b/nomic/embed.py
@@ -224,7 +224,6 @@ def _text_atlas(
 
 _embed4all: Embed4All | None = None
 _embed4all_kwargs: dict[str, Any] | None = None
-_embed4all_has_init_gpu = False
 
 
 def _text_embed4all(
@@ -236,7 +235,7 @@ def _text_embed4all(
     dynamic_mode: bool,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    global _embed4all, _embed4all_kwargs, _embed4all_has_init_gpu
+    global _embed4all, _embed4all_kwargs
 
     try:
         g4a_model = _EMBED4ALL_MODELS[model]
@@ -251,15 +250,10 @@ def _text_embed4all(
         return {"embeddings": [], "usage": {}, "model": model, "inference_mode": "local"}
 
     if _embed4all is None or _embed4all.gpt4all.config["filename"] != g4a_model or _embed4all_kwargs != kwargs:
-        using_gpu = kwargs.get("device") not in (None, "cpu")
-        if using_gpu and _embed4all_has_init_gpu:
-            raise NotImplementedError("GPU context can only be initialized once")
-
+        if _embed4all is not None:
+            _embed4all.close()
         _embed4all = Embed4All(g4a_model, **kwargs)
         _embed4all_kwargs = kwargs
-
-        if using_gpu:
-            _embed4all_has_init_gpu = True
 
     def cancel_cb(batch_sizes: list[int], backend: str) -> bool:
         # TODO(jared): make this more accurate

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     extras_require={
         'local': [
-            'gpt4all>=2.4.0,<3',
+            'gpt4all>=2.5.0,<3',
         ],
         'aws': [
             'boto3',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url='https://github.com/nomic-ai/nomic',
     description=description,
     long_description=description,
-    packages=find_packages(),
+    packages=find_packages(include=['nomic', 'nomic.*']),
     author_email="support@nomic.ai",
     author="nomic.ai",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ description = 'The official Nomic python client.'
     
 setup(
     name='nomic',
-    version='3.0.22',
+    version='3.0.23',
     url='https://github.com/nomic-ai/nomic',
     description=description,
     long_description=description,

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -15,19 +15,11 @@ def _test_local(text='x', n_tokens=1, dimensionality=None, **kwargs):
     assert len(embedding) == dimensionality or 768  # n_embd
 
 
-# TODO(jared): Empty string fails to embed due to tokenization issues.
-#              Should be fixed by llama.cpp PR #6498
-#@parametrize('text,n_tokens', [('The quick brown fox jumps over the lazy dog.', 10), ('', 0)])
-@parametrize('text,n_tokens', [('The quick brown fox jumps over the lazy dog.', 10)])
+# empty string counts as 23 tokens because it embeds md5('nomic empty') instead
+@parametrize('text,n_tokens', [('The quick brown fox jumps over the lazy dog.', 10), ('', 23)])
 def test_embed_local(text, n_tokens):
     """local inference works"""
     _test_local(text, n_tokens)
-
-
-def test_embed_empty_text():
-    """embedding an empty string locally is not implemented"""
-    with pytest.raises(NotImplementedError):
-        embed.text([''], inference_mode='local')
 
 
 def test_embed_empty_list():


### PR DESCRIPTION
This PR implements a simple version of dynamic mode for embed.text, using the new cancel_cb parameter of `Embed4All.embed`.

It also fixes the issues outlined in https://github.com/nomic-ai/nomic/pull/287#issuecomment-2050187415.

~~Leaving as a draft pending the merge of https://github.com/nomic-ai/gpt4all/pull/2214 and release of a new version of the gpt4all bindings.~~ Done.

Follow-up to #287