### PR TITLE
Matryoshka and Binary Options for Sagemaker

### DIFF
--- a/examples/sagemaker/run-nomic-embed-text.ipynb
+++ b/examples/sagemaker/run-nomic-embed-text.ipynb
@@ -13,7 +13,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6c5e13f4",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "!pip install nomic\n",
@@ -22,19 +24,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "cc3b38b6-34ef-48bd-923d-938b88471873",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sagemaker.config INFO - Not applying SDK defaults from location: /etc/xdg/sagemaker/config.yaml\n",
-      "sagemaker.config INFO - Not applying SDK defaults from location: /home/ec2-user/.config/sagemaker/config.yaml\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -68,7 +61,7 @@
    "source": [
     "## Real Time Inference\n",
     "Run `embed_text` for real time inference.\n",
-    "The method will return a `np.float16 array`."
+    "The method will return a nested list of floats. "
    ]
   },
   {
@@ -184,9 +177,44 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b29175ef",
+   "metadata": {},
+   "source": [
+    "## Batch Transform\n",
+    "\n",
+    "Nomic Embed on Sagemaker also supports [batch transform jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html) over CSV files.\n",
+    "To run batch transform, make sure your csv contains rows of single column text without headers.\n",
+    "\n",
+    "Optionally, in the first row, you can pass two columns: an integer value (valid options are 64, 128, 256, 512, 768) and a boolean. If the first row matches this format, these values will be treated as the dimensionality to return the embeddings in and whether to return binary embeddings or not. Otherwise, the first row will be treated as single column text as well (i.e. the first column will be cast to string and embedded).\n",
+    "\n",
+    "For example, a valid input csv can look like:\n",
+    "\n",
+    "```\n",
+    "128, True\n",
+    "Hello world\n",
+    "Hello world\n",
+    "Hello world\n",
+    "```\n",
+    "\n",
+    "This will return three 128 dimension binary embeddings.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bc6470f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nomic.aws.sagemaker import batch_transform"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8823719f-3da3-447f-9989-8890bdfa1be0",
+   "id": "24509f3a",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -208,7 +236,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/sagemaker/run-nomic-embed-text.ipynb
+++ b/examples/sagemaker/run-nomic-embed-text.ipynb
@@ -22,10 +22,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 1,
    "id": "cc3b38b6-34ef-48bd-923d-938b88471873",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sagemaker.config INFO - Not applying SDK defaults from location: /etc/xdg/sagemaker/config.yaml\n",
+      "sagemaker.config INFO - Not applying SDK defaults from location: /home/ec2-user/.config/sagemaker/config.yaml\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -43,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "cf4e8007-3fa2-473b-8748-7aa4de26cb2f",
    "metadata": {},
    "outputs": [],
@@ -64,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "9bd45a53-de0a-4a63-af40-731c218b4ea4",
    "metadata": {},
    "outputs": [],
@@ -81,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 18,
    "id": "a668e03f-9a50-4b3d-9a02-a059136af6b9",
    "metadata": {},
    "outputs": [
@@ -89,60 +98,95 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  2.93it/s]\n"
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  6.96it/s]\n"
      ]
-    }
-   ],
-   "source": [
-    "response = embed_texts(texts, endpoint_name, region_name=region_name, batch_size=32)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "3b704bd6-5951-40c3-ba26-dfdedb4a7ff1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "embeddings = response[\"embeddings\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "d0a81001-a832-4b27-b9ec-65ec68b133e8",
-   "metadata": {},
-   "outputs": [
+    },
     {
      "data": {
       "text/plain": [
-       "array([[ 0.03738403,  0.00876617, -0.1116333 , ..., -0.04412842,\n",
-       "        -0.04345703, -0.0524292 ],\n",
-       "       [ 0.03637695,  0.01615906, -0.12445068, ..., -0.04266357,\n",
-       "        -0.06054688, -0.05432129],\n",
-       "       [ 0.05923462,  0.02310181, -0.1315918 , ..., -0.05889893,\n",
-       "        -0.03872681, -0.04345703],\n",
-       "       [-0.01360321,  0.04324341, -0.16638184, ..., -0.05523682,\n",
-       "        -0.07879639, -0.00566101],\n",
-       "       [-0.01360321,  0.04324341, -0.16638184, ..., -0.05523682,\n",
-       "        -0.07879639, -0.00566101],\n",
-       "       [-0.01360321,  0.04324341, -0.16638184, ..., -0.05523682,\n",
-       "        -0.07879639, -0.00566101]])"
+       "(6, 768)"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "response = embed_texts(texts, endpoint_name, region_name=region_name, batch_size=32)\n",
+    "embeddings = response[\"embeddings\"]\n",
+    "np.array(embeddings).shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "4375e4a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  6.27it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(6, 128)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response = embed_texts(texts, endpoint_name, region_name=region_name, batch_size=32, dimensions=128)\n",
+    "embeddings = response[\"embeddings\"]\n",
+    "np.array(embeddings).shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "64072bef-4c92-425b-a6cd-c3c3ee82389a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  7.79it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([[1, 1, 0, ..., 0, 0, 0],\n",
+       "       [1, 1, 0, ..., 0, 0, 0],\n",
+       "       [1, 1, 0, ..., 0, 0, 0],\n",
+       "       [0, 1, 0, ..., 0, 0, 0],\n",
+       "       [0, 1, 0, ..., 0, 0, 0],\n",
+       "       [0, 1, 0, ..., 0, 0, 0]])"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response = embed_texts(texts, endpoint_name, region_name=region_name, batch_size=32, binary=True)\n",
+    "embeddings = response[\"embeddings\"]\n",
     "np.array(embeddings)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4375e4a5",
+   "id": "8823719f-3da3-447f-9989-8890bdfa1be0",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/examples/sagemaker/run-nomic-embed-text.ipynb
+++ b/examples/sagemaker/run-nomic-embed-text.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "cc3b38b6-34ef-48bd-923d-938b88471873",
    "metadata": {},
    "outputs": [
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "9bd45a53-de0a-4a63-af40-731c218b4ea4",
    "metadata": {},
    "outputs": [],
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 4,
    "id": "a668e03f-9a50-4b3d-9a02-a059136af6b9",
    "metadata": {},
    "outputs": [
@@ -100,7 +100,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  6.96it/s]\n"
+      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  2.13it/s]\n"
      ]
     },
     {
@@ -109,7 +109,7 @@
        "(6, 768)"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 6,
    "id": "4375e4a5",
    "metadata": {},
    "outputs": [
@@ -130,7 +130,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  6.27it/s]\n"
+      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  7.64it/s]\n"
      ]
     },
     {
@@ -139,20 +139,20 @@
        "(6, 128)"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "response = embed_texts(texts, endpoint_name, region_name=region_name, batch_size=32, dimensions=128)\n",
+    "response = embed_texts(texts, endpoint_name, region_name=region_name, batch_size=32, dimensionality=128)\n",
     "embeddings = response[\"embeddings\"]\n",
     "np.array(embeddings).shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 7,
    "id": "64072bef-4c92-425b-a6cd-c3c3ee82389a",
    "metadata": {},
    "outputs": [
@@ -160,7 +160,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  7.79it/s]\n"
+      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  7.29it/s]\n"
      ]
     },
     {
@@ -174,7 +174,7 @@
        "       [0, 1, 0, ..., 0, 0, 0]])"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/sagemaker/run-nomic-embed-text.ipynb
+++ b/examples/sagemaker/run-nomic-embed-text.ipynb
@@ -18,16 +18,25 @@
    },
    "outputs": [],
    "source": [
-    "!pip install nomic\n",
+    "!pip install nomic'[aws]'\n",
     "!pip install numpy"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "cc3b38b6-34ef-48bd-923d-938b88471873",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sagemaker.config INFO - Not applying SDK defaults from location: /etc/xdg/sagemaker/config.yaml\n",
+      "sagemaker.config INFO - Not applying SDK defaults from location: /home/ec2-user/.config/sagemaker/config.yaml\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -198,17 +207,8 @@
     "```\n",
     "\n",
     "This will return three 128 dimension binary embeddings.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "bc6470f9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from nomic.aws.sagemaker import batch_transform"
+    "\n",
+    "You can launch a batch transform job with the `nomic` package:"
    ]
   },
   {
@@ -217,7 +217,19 @@
    "id": "24509f3a",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from nomic.aws.sagemaker import batch_transform\n",
+    "\n",
+    "batch_transform(\n",
+    "    s3_input_path=\"s3://batch-transform/input.csv\",\n",
+    "    s3_output_path=\"s3://batch-transform/\",\n",
+    "    region_name=\"us-east-2\",\n",
+    "    arn='<INSERT MODEL PACKAGE ARN>',\n",
+    "    role='<INSERT SAGEMAKER EXECUTOR IAM ROLE ARN>',\n",
+    "    max_payload=6,\n",
+    "    n_instances=1\n",
+    ")"
+   ]
   }
  ],
  "metadata": {
@@ -236,7 +248,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/nomic/aws/sagemaker.py
+++ b/nomic/aws/sagemaker.py
@@ -15,9 +15,7 @@ def _get_sagemaker_role():
     try:
         return sagemaker.get_execution_role()
     except ValueError:
-        raise ValueError(
-            "Unable to fetch sagemaker execution role. Please provide a role."
-        )
+        raise ValueError("Unable to fetch sagemaker execution role. Please provide a role.")
 
 
 def parse_sagemaker_response(response):
@@ -174,9 +172,7 @@ def embed_texts(
                 "dimensionality": dimensionality,
             }
         )
-        response = client.invoke_endpoint(
-            EndpointName=sagemaker_endpoint, Body=batch, ContentType="application/json"
-        )
+        response = client.invoke_endpoint(EndpointName=sagemaker_endpoint, Body=batch, ContentType="application/json")
         embeddings.extend(parse_sagemaker_response(response))
 
     return {

--- a/nomic/aws/sagemaker.py
+++ b/nomic/aws/sagemaker.py
@@ -129,6 +129,8 @@ def embed_texts(
     region_name: str,
     task_type: str = "search_document",
     batch_size: int = 32,
+    dimensionality: int = 768,
+    binary: bool = False,
 ):
     """
     Embed a list of texts using a sagemaker model endpoint.
@@ -139,6 +141,8 @@ def embed_texts(
         region_name: AWS region sagemaker endpoint is in.
         task_type: The task type to use when embedding.
         batch_size: Size of each batch. Default is 32.
+        dimensionality: Number of dimensions to return. Options are (64, 128, 256, 512, 768).
+        binary: Whether to return binary embeddings.
 
     Returns:
         Dictionary with "embeddings" (python 2d list of floats), "model" (sagemaker endpoint used to generate embeddings).
@@ -149,13 +153,28 @@ def embed_texts(
         return None
 
     texts = preprocess_texts(texts, task_type)
+    assert dimensionality in (
+        64,
+        128,
+        256,
+        512,
+        768,
+    ), f"Invalid number of dimensions: {dimensionality}"
 
     client = boto3.client("sagemaker-runtime", region_name=region_name)
     embeddings = []
 
     for i in tqdm(range(0, len(texts), batch_size)):
-        batch = json.dumps({"texts": texts[i : i + batch_size]})
-        response = client.invoke_endpoint(EndpointName=sagemaker_endpoint, Body=batch, ContentType="application/json")
+        batch = json.dumps(
+            {
+                "texts": texts[i : i + batch_size],
+                "binary": binary,
+                "dimensionality": dimensionality,
+            }
+        )
+        response = client.invoke_endpoint(
+            EndpointName=sagemaker_endpoint, Body=batch, ContentType="application/json"
+        )
         embeddings.extend(parse_sagemaker_response(response))
 
     return {

--- a/nomic/aws/sagemaker.py
+++ b/nomic/aws/sagemaker.py
@@ -15,7 +15,9 @@ def _get_sagemaker_role():
     try:
         return sagemaker.get_execution_role()
     except ValueError:
-        raise ValueError("Unable to fetch sagemaker execution role. Please provide a role.")
+        raise ValueError(
+            "Unable to fetch sagemaker execution role. Please provide a role."
+        )
 
 
 def parse_sagemaker_response(response):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ description = 'The official Nomic python client.'
     
 setup(
     name='nomic',
-    version='3.0.24',
+    version='3.0.25',
     url='https://github.com/nomic-ai/nomic',
     description=description,
     long_description=description,


### PR DESCRIPTION
Adds in options to get binary or reduced dimensions from returned sagemaker embeddings.
Updates example notebook to show binary and matryoshka options.

Note: I did not add this in for batch transform as it would require the user to know how to format their csvs to pass the parameters.


