### PR TITLE
[wip] Safe download of embeddings

### DIFF
--- a/nomic/aws/sagemaker.py
+++ b/nomic/aws/sagemaker.py
@@ -232,7 +232,6 @@ def embed_image(
     region_name: str,
     model_name="nomic-embed-vision-v1",
 ) -> dict:
-
     embeddings = []
 
     max_workers = mp.cpu_count()

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -706,20 +706,7 @@ class AtlasMapTags:
             quad_str = os.path.join(*[str(q) for q in quad])
             filename = quad_str + "." + f"_tag.{tag_definition_id}" + ".feather"
             path = self.projection.tile_destination / Path(filename)
-            download_attempt = 0
-            download_success = False
-            while download_attempt < 3 and not download_success:
-                download_attempt += 1
-                if not path.exists() or overwrite:
-                    download_feather(root_url + filename, path, headers=self.dataset.header)
-                try:
-                    ipc.open_file(path).schema
-                    download_success = True
-                except pa.ArrowInvalid:
-                    path.unlink(missing_ok=True)
-
-            if not download_success:
-                raise Exception(f"Failed to download tag {tag_name}.")
+            download_feather(root_url + filename, path, headers=self.dataset.header, overwrite=True)
             ordered_tag_paths.append(path)
         return ordered_tag_paths
 
@@ -860,10 +847,8 @@ class AtlasMapData:
                 quad_str = os.path.join(*[str(q) for q in quad])
                 filename = quad_str + "." + encoded_colname + ".feather"
                 path = self.projection.tile_destination / Path(filename)
-
-                if not os.path.exists(path):
-                    # WARNING: Potentially large data request here
-                    download_feather(root + filename, path, headers=self.dataset.header)
+                # WARNING: Potentially large data request here
+                download_feather(root + filename, path, headers=self.dataset.header, overwrite=False)
 
         return sidecars
 

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -440,7 +440,7 @@ class AtlasMapEmbeddings:
         Returns the path to downloaded embeddings.
         """
         self.projection.tile_destination.mkdir(parents=True, exist_ok=True)
-        root = f"{self.dataset.atlas_api_path}/v1/project/{self.dataset.id}/index/projection/{self.projection.id}/quadtree/"
+        root_url = f"{self.dataset.atlas_api_path}/v1/project/{self.dataset.id}/index/projection/{self.projection.id}/quadtree/"
 
         registered_sidecar_names = [sidecar[1] for sidecar in self.projection._registered_sidecars()]
         assert "embeddings" in registered_sidecar_names, "Embeddings not found in sidecars."

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -1,4 +1,3 @@
-from atexit import register
 import base64
 import concurrent
 import concurrent.futures
@@ -6,6 +5,7 @@ import glob
 import io
 import json
 import os
+from atexit import register
 from collections import defaultdict
 from datetime import datetime
 from io import BytesIO

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -439,6 +439,7 @@ class AtlasMapEmbeddings:
         Downloads the feather tree for embeddings.
         Returns the path to downloaded embeddings.
         """
+        # TODO: Is size of the embedding files (several hundreds of MBs) going to be a problem here?
         self.projection.tile_destination.mkdir(parents=True, exist_ok=True)
         root_url = Path(
             f"{self.dataset.atlas_api_path}/v1/project/{self.dataset.id}/index/projection/{self.projection.id}/quadtree/"

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -440,7 +440,9 @@ class AtlasMapEmbeddings:
         Returns the path to downloaded embeddings.
         """
         self.projection.tile_destination.mkdir(parents=True, exist_ok=True)
-        root_url = f"{self.dataset.atlas_api_path}/v1/project/{self.dataset.id}/index/projection/{self.projection.id}/quadtree/"
+        root_url = Path(
+            f"{self.dataset.atlas_api_path}/v1/project/{self.dataset.id}/index/projection/{self.projection.id}/quadtree/"
+        )
 
         registered_sidecar_names = [sidecar[1] for sidecar in self.projection._registered_sidecars()]
         assert "embeddings" in registered_sidecar_names, "Embeddings not found in sidecars."
@@ -448,10 +450,11 @@ class AtlasMapEmbeddings:
         downloaded_files_in_tile_order = []
         logger.info("Downloading latent embeddings...")
         all_quads = list(self.projection._tiles_in_order())
-        for base_tile in tqdm(all_quads):
-            path = base_tile.with_suffix(".embeddings.feather")
+        for quad in tqdm(all_quads):
+            path = quad.with_suffix(".embeddings.feather")
             # WARNING: Potentially large data request here
-            download_feather(Path(root_url, *path.parts[-3:]), path, headers=self.dataset.header, overwrite=False)
+            quadtree_loc = Path(*path.parts[-3:])
+            download_feather(root_url / quadtree_loc, path, headers=self.dataset.header, overwrite=False)
             downloaded_files_in_tile_order.append(path)
         return downloaded_files_in_tile_order
 

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -440,8 +440,8 @@ class AtlasMapEmbeddings:
         self.projection.tile_destination.mkdir(parents=True, exist_ok=True)
         root = f"{self.dataset.atlas_api_path}/v1/project/{self.dataset.id}/index/projection/{self.projection.id}/quadtree/"
 
-        registered_sidecars = self.projection._registered_sidecars()
-        assert "embeddings" in registered_sidecars, "Embeddings not found in sidecars."
+        registered_sidecar_names = [sidecar[1] for sidecar in self.projection._registered_sidecars()]
+        assert "embeddings" in registered_sidecar_names, "Embeddings not found in sidecars."
 
         downloaded_files_in_tile_order = []
         all_quads = list(self.projection._tiles_in_order(coords_only=True))

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -451,7 +451,7 @@ class AtlasMapEmbeddings:
         for base_tile in tqdm(all_quads):
             path = base_tile.with_suffix(".embeddings.feather")
             # WARNING: Potentially large data request here
-            download_feather(root + filename, path, headers=self.dataset.header, overwrite=False)
+            download_feather(Path(root_url, *path.parts[-3:]), path, headers=self.dataset.header, overwrite=False)
             downloaded_files_in_tile_order.append(path)
         return downloaded_files_in_tile_order
 

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -1,14 +1,9 @@
 import base64
-import concurrent
-import concurrent.futures
-import glob
 import io
 import json
 import os
-from atexit import register
 from collections import defaultdict
 from datetime import datetime
-from io import BytesIO
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
 
@@ -16,9 +11,8 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import requests
-from loguru import logger
 from pyarrow import compute as pc
-from pyarrow import feather, ipc
+from pyarrow import feather
 from tqdm import tqdm
 
 from .settings import EMBEDDING_PAGINATION_LIMIT

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -447,11 +447,9 @@ class AtlasMapEmbeddings:
 
         downloaded_files_in_tile_order = []
         logger.info("Downloading latent embeddings...")
-        all_quads = list(self.projection._tiles_in_order(coords_only=True))
-        for quad in tqdm(all_quads):
-            quad_str = os.path.join(*[str(q) for q in quad])
-            filename = quad_str + "." + "embeddings" + ".feather"
-            path = self.projection.tile_destination / Path(filename)
+        all_quads = list(self.projection._tiles_in_order())
+        for base_tile in tqdm(all_quads):
+            path = base_tile.with_suffix(".embeddings.feather")
             # WARNING: Potentially large data request here
             download_feather(root + filename, path, headers=self.dataset.header, overwrite=False)
             downloaded_files_in_tile_order.append(path)

--- a/nomic/data_operations.py
+++ b/nomic/data_operations.py
@@ -437,7 +437,6 @@ class AtlasMapEmbeddings:
             dims = tb["_embeddings"].type.list_size
             all_embeddings.append(pa.compute.list_flatten(tb["_embeddings"]).to_numpy().reshape(-1, dims))  # type: ignore
         return np.vstack(all_embeddings)
-    
 
     def _download_latent(self) -> List[Path]:
         """

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -611,6 +611,7 @@ class AtlasProjection:
         """
         if self._tile_data is not None:
             return self._tile_data
+        logger.info(f"Downloading files for projection {self.projection_id}")
         self._download_large_feather(overwrite=overwrite)
         tbs = []
         root = feather.read_table(self.tile_destination / "0/0/0.feather", memory_map=True)

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -633,16 +633,13 @@ class AtlasProjection:
         return self._tile_data
 
     @overload
-    def _tiles_in_order(self, *, coords_only: Literal[False] = ...) -> Iterator[Path]:
-        ...
+    def _tiles_in_order(self, *, coords_only: Literal[False] = ...) -> Iterator[Path]: ...
 
     @overload
-    def _tiles_in_order(self, *, coords_only: Literal[True]) -> Iterator[Tuple[int, int, int]]:
-        ...
+    def _tiles_in_order(self, *, coords_only: Literal[True]) -> Iterator[Tuple[int, int, int]]: ...
 
     @overload
-    def _tiles_in_order(self, *, coords_only: bool) -> Iterator[Any]:
-        ...
+    def _tiles_in_order(self, *, coords_only: bool) -> Iterator[Any]: ...
 
     def _tiles_in_order(self, *, coords_only: bool = False) -> Iterator[Any]:
         """

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -633,11 +633,16 @@ class AtlasProjection:
         return self._tile_data
 
     @overload
-    def _tiles_in_order(self, *, coords_only: Literal[False] = ...) -> Iterator[Path]: ...
+    def _tiles_in_order(self, *, coords_only: Literal[False] = ...) -> Iterator[Path]:
+        ...
+
     @overload
-    def _tiles_in_order(self, *, coords_only: Literal[True]) -> Iterator[Tuple[int, int, int]]: ...
+    def _tiles_in_order(self, *, coords_only: Literal[True]) -> Iterator[Tuple[int, int, int]]:
+        ...
+
     @overload
-    def _tiles_in_order(self, *, coords_only: bool) -> Iterator[Any]: ...
+    def _tiles_in_order(self, *, coords_only: bool) -> Iterator[Any]:
+        ...
 
     def _tiles_in_order(self, *, coords_only: bool = False) -> Iterator[Any]:
         """
@@ -693,7 +698,7 @@ class AtlasProjection:
             quad = rawquad + ".feather"
             all_quads.append(quad)
             path = self.tile_destination / quad
-            schema = download_feather(root+quad, path, headers=self.dataset.header, overwrite=overwrite)
+            schema = download_feather(root + quad, path, headers=self.dataset.header, overwrite=overwrite)
 
             if sidecars is None and b"sidecars" in schema.metadata:
                 # Grab just the filenames

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -36,7 +36,7 @@ from .data_inference import (
 )
 from .data_operations import AtlasMapData, AtlasMapDuplicates, AtlasMapEmbeddings, AtlasMapTags, AtlasMapTopics
 from .settings import *
-from .utils import assert_valid_project_id, get_object_size_in_bytes
+from .utils import assert_valid_project_id, download_feather
 
 
 class AtlasUser:
@@ -693,27 +693,7 @@ class AtlasProjection:
             quad = rawquad + ".feather"
             all_quads.append(quad)
             path = self.tile_destination / quad
-
-            download_attempt = 0
-            download_success = False
-            schema = None
-            while download_attempt < 3 and not download_success:
-                download_attempt += 1
-                if not path.exists() or overwrite:
-                    data = requests.get(root + quad, headers=self.dataset.header)
-                    readable = io.BytesIO(data.content)
-                    readable.seek(0)
-                    tb = feather.read_table(readable, memory_map=True)
-                    path.parent.mkdir(parents=True, exist_ok=True)
-                    feather.write_feather(tb, path)
-                try:
-                    schema = ipc.open_file(path).schema
-                    download_success = True
-                except pa.ArrowInvalid:
-                    path.unlink(missing_ok=True)
-
-            if not download_success or schema is None:
-                raise Exception(f"Failed to download tiles. Aborting...")
+            schema = download_feather(root+quad, path, headers=self.dataset.header, overwrite=overwrite)
 
             if sidecars is None and b"sidecars" in schema.metadata:
                 # Grab just the filenames

--- a/nomic/embed.py
+++ b/nomic/embed.py
@@ -102,7 +102,8 @@ def text(
     dimensionality: int | None = ...,
     long_text_mode: str = ...,
     inference_mode: Literal["remote"] = ...,
-) -> dict[str, Any]: ...
+) -> dict[str, Any]:
+    ...
 
 
 @overload
@@ -116,7 +117,8 @@ def text(
     inference_mode: Literal["local", "dynamic"],
     device: str | None = ...,
     **kwargs: Any,
-) -> dict[str, Any]: ...
+) -> dict[str, Any]:
+    ...
 
 
 @overload
@@ -130,7 +132,8 @@ def text(
     inference_mode: str,
     device: str | None = ...,
     **kwargs: Any,
-) -> dict[str, Any]: ...
+) -> dict[str, Any]:
+    ...
 
 
 def text(

--- a/nomic/embed.py
+++ b/nomic/embed.py
@@ -102,8 +102,7 @@ def text(
     dimensionality: int | None = ...,
     long_text_mode: str = ...,
     inference_mode: Literal["remote"] = ...,
-) -> dict[str, Any]:
-    ...
+) -> dict[str, Any]: ...
 
 
 @overload
@@ -117,8 +116,7 @@ def text(
     inference_mode: Literal["local", "dynamic"],
     device: str | None = ...,
     **kwargs: Any,
-) -> dict[str, Any]:
-    ...
+) -> dict[str, Any]: ...
 
 
 @overload
@@ -132,8 +130,7 @@ def text(
     inference_mode: str,
     device: str | None = ...,
     **kwargs: Any,
-) -> dict[str, Any]:
-    ...
+) -> dict[str, Any]: ...
 
 
 def text(

--- a/nomic/utils.py
+++ b/nomic/utils.py
@@ -257,7 +257,7 @@ def download_feather(url: str, path: Path, headers: Optional[dict] = None, retri
             data = requests.get(url, headers=headers)
             readable = BytesIO(data.content)
             readable.seek(0)
-            tb = pa.feather.read_table(readable, memory_map=False) # type: ignore
+            tb = pa.feather.read_table(readable, memory_map=False)  # type: ignore
             path.parent.mkdir(parents=True, exist_ok=True)
             pa.feather.write_feather(tb, path)
         try:

--- a/nomic/utils.py
+++ b/nomic/utils.py
@@ -4,7 +4,7 @@ import random
 import sys
 from io import BytesIO
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 from uuid import UUID
 
 import pyarrow as pa
@@ -242,7 +242,9 @@ def get_object_size_in_bytes(obj):
 
 # Helpful function for downloading feather files
 # Best for small feather files
-def download_feather(url: str, path: Path, headers: Optional[dict] = None, retries=3, overwrite=False) -> pa.Schema:
+def download_feather(
+    url: Union[str, Path], path: Path, headers: Optional[dict] = None, retries=3, overwrite=False
+) -> pa.Schema:
     """
     Download a feather file from a URL to a local path.
     Returns the schema of feather file if successful.
@@ -254,7 +256,7 @@ def download_feather(url: str, path: Path, headers: Optional[dict] = None, retri
     while download_attempt < retries and not download_success:
         download_attempt += 1
         if not path.exists() or overwrite:
-            data = requests.get(url, headers=headers)
+            data = requests.get(str(url), headers=headers)
             readable = BytesIO(data.content)
             readable.seek(0)
             tb = pa.feather.read_table(readable, memory_map=False)  # type: ignore

--- a/nomic/utils.py
+++ b/nomic/utils.py
@@ -8,8 +8,8 @@ from typing import Optional
 from uuid import UUID
 
 import pyarrow as pa
-from pyarrow import ipc
 import requests
+from pyarrow import ipc
 
 nouns = [
     "newton",

--- a/nomic/utils.py
+++ b/nomic/utils.py
@@ -259,7 +259,7 @@ def download_feather(url: str, path: Path, headers: Optional[dict] = None, retri
             readable.seek(0)
             tb = pa.feather.read_table(readable, memory_map=False)  # type: ignore
             path.parent.mkdir(parents=True, exist_ok=True)
-            pa.feather.write_feather(tb, path)
+            pa.feather.write_feather(tb, path)  # type: ignore
         try:
             schema = ipc.open_file(path).schema
             download_success = True

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ description = "The official Nomic python client."
 
 setup(
     name="nomic",
-    version="3.0.31",
+    version="3.0.32",
     url="https://github.com/nomic-ai/nomic",
     description=description,
     long_description=description,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         ],
         "dev": [
             "nomic[all]",
-            "black",
+            "black==24.3.0",
             "coverage",
             "pylint",
             "pytest",


### PR DESCRIPTION
Download embeddings using existing sidecar routes rather than a separate endpoint. 
Use download utils that has some guarantees about cleaning up bad files and doing retries.