### PR TITLE
Add's topic label field as pydantic param for documentation generation NOM-1661

### DIFF
--- a/nomic/data_inference.py
+++ b/nomic/data_inference.py
@@ -84,11 +84,11 @@ class NomicTopicOptions(BaseModel):
 
     Args:
         build_topic_model: If True, builds a topic model over your dataset's embeddings.
-        community_description_target_field: The dataset field/column that Atlas will use to assign a human-readable description to each topic.
+        topic_label_field: The dataset column (usually the column you embedded) that Atlas will use to assign a human-readable description to each topic.
     """
 
     build_topic_model: bool = True
-    community_description_target_field: Optional[str] = Field(default=None, alias="topic_label_field")
+    topic_label_field: Optional[str] = Field(default=None, alias="community_description_target_field")
     cluster_method: str = "fast"
     enforce_topic_hierarchy: bool = False
 

--- a/nomic/data_inference.py
+++ b/nomic/data_inference.py
@@ -93,12 +93,12 @@ class NomicTopicOptions(BaseModel):
     enforce_topic_hierarchy: bool = False
 
     def dict(self, **kwargs):
-        #TODO can be removed after Atlas Cloud v0.0.85 reaches all released tenants
+        # TODO can be removed after Atlas Cloud v0.0.85 reaches all released tenants
         # Get the original dictionary
         original_dict = super().dict(**kwargs)
         # Replace the key if topic_label_field exists in the original dictionary
-        if 'topic_label_field' in original_dict:
-            original_dict['community_description_target_field'] = original_dict.pop('topic_label_field')
+        if "topic_label_field" in original_dict:
+            original_dict["community_description_target_field"] = original_dict.pop("topic_label_field")
         return original_dict
 
 

--- a/nomic/data_inference.py
+++ b/nomic/data_inference.py
@@ -88,18 +88,9 @@ class NomicTopicOptions(BaseModel):
     """
 
     build_topic_model: bool = True
-    topic_label_field: Optional[str] = Field(default=None)
+    topic_label_field: Optional[str] = Field(default=None, alias="community_description_target_field")
     cluster_method: str = "fast"
     enforce_topic_hierarchy: bool = False
-
-    def dict(self, **kwargs):
-        # TODO can be removed after Atlas Cloud v0.0.85 reaches all released tenants
-        # Get the original dictionary
-        original_dict = super().dict(**kwargs)
-        # Replace the key if topic_label_field exists in the original dictionary
-        if "topic_label_field" in original_dict:
-            original_dict["community_description_target_field"] = original_dict.pop("topic_label_field")
-        return original_dict
 
 
 class NomicDuplicatesOptions(BaseModel):

--- a/nomic/data_inference.py
+++ b/nomic/data_inference.py
@@ -88,9 +88,18 @@ class NomicTopicOptions(BaseModel):
     """
 
     build_topic_model: bool = True
-    topic_label_field: Optional[str] = Field(default=None, alias="community_description_target_field")
+    topic_label_field: Optional[str] = Field(default=None)
     cluster_method: str = "fast"
     enforce_topic_hierarchy: bool = False
+
+    def dict(self, **kwargs):
+        #TODO can be removed after Atlas Cloud v0.0.85 reaches all released tenants
+        # Get the original dictionary
+        original_dict = super().dict(**kwargs)
+        # Replace the key if topic_label_field exists in the original dictionary
+        if 'topic_label_field' in original_dict:
+            original_dict['community_description_target_field'] = original_dict.pop('topic_label_field')
+        return original_dict
 
 
 class NomicDuplicatesOptions(BaseModel):

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1143,7 +1143,7 @@ class AtlasDataset(AtlasClass):
 
         build_template = {}
         if self.modality == "embedding":
-            if topic_model.community_description_target_field is None:
+            if topic_model.topic_label_field is None:
                 logger.warning(
                     "You did not specify the `topic_label_field` option in your topic_model, your dataset will not contain auto-labeled topics."
                 )
@@ -1171,7 +1171,7 @@ class AtlasDataset(AtlasClass):
                 "topic_model_hyperparameters": json.dumps(
                     {
                         "build_topic_model": topic_model.build_topic_model,
-                        "community_description_target_field": topic_model.community_description_target_field,
+                        "community_description_target_field": topic_model.topic_label_field,  # TODO change key to topic_label_field post v0.0.85
                         "cluster_method": topic_model.cluster_method,
                         "enforce_topic_hierarchy": topic_model.enforce_topic_hierarchy,
                     }
@@ -1236,7 +1236,7 @@ class AtlasDataset(AtlasClass):
                 "topic_model_hyperparameters": json.dumps(
                     {
                         "build_topic_model": topic_model.build_topic_model,
-                        "community_description_target_field": indexed_field,
+                        "community_description_target_field": indexed_field,  # TODO change key to topic_label_field post v0.0.85
                         "cluster_method": topic_model.build_topic_model,
                         "enforce_topic_hierarchy": topic_model.enforce_topic_hierarchy,
                     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 646b08cc49ee96b0b4e684a94500fd84357bcdfc  | 
|--------|--------|

### Summary:
Renamed a field in `NomicTopicOptions` for clarity, updated relevant classes and methods, and ensured backward compatibility across multiple files.

**Key points**:
- Renamed `community_description_target_field` to `topic_label_field` in `nomic/data_inference.py`.
- Updated `NomicTopicOptions` class to use `topic_label_field` with alias `community_description_target_field`.
- Adjusted the `Field` alias for backward compatibility.
- Modified `NomicTopicOptions.dict` method to replace `topic_label_field` with `community_description_target_field` for backward compatibility.
- Modified `nomic/dataset.py` to use `topic_label_field` instead of `community_description_target_field`.
- Ensured backward compatibility by using alias in `Field` and updating `create_index` method.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->