### PR TITLE
Display dataset link instead of map link

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -438,6 +438,13 @@ class AtlasProjection:
         # return f"{self.project.web_path}/data/{self.project.meta['organization_slug']}/{self.project.meta['slug']}/map"
 
     @property
+    def dataset_link(self):
+        """
+        Retrieves a dataset link.
+        """
+        return f"{self.dataset.web_path}/data/{self.dataset.meta['organization_slug']}/{self.dataset.meta['slug']}"
+
+    @property
     def _status(self):
         response = requests.get(
             self.dataset.atlas_api_path + f"/v1/project/index/job/progress/{self.atlas_index_id}",
@@ -450,7 +457,7 @@ class AtlasProjection:
         return content
 
     def __str__(self):
-        return f"{self.name}: {self.map_link}"
+        return f"{self.name}: {self.dataset_link}"
 
     def __repr__(self):
         return self.__str__()
@@ -1039,7 +1046,7 @@ class AtlasDataset(AtlasClass):
             embedding_model: Options for configuring the embedding model
 
         Returns:
-            The projection this index has built.
+            The dataset page for the index.
 
         """
 

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1046,7 +1046,7 @@ class AtlasDataset(AtlasClass):
             embedding_model: Options for configuring the embedding model
 
         Returns:
-            The dataset page for the index.
+            The projection this index has built.
 
         """
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ description = "The official Nomic python client."
 
 setup(
     name="nomic",
-    version="3.0.34",
+    version="3.0.35",
     url="https://github.com/nomic-ai/nomic",
     description=description,
     long_description=description,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit cd8423ae53b7ff0ed3bbf4e979b01ab9d4715a7f  | 
|--------|--------|

### Summary:
Added `dataset_link` property to `AtlasProjection`, updated `__str__` method, and incremented version to `3.0.35`.

**Key points**:
- Added `dataset_link` property to `nomic/dataset.py:AtlasProjection` to retrieve dataset link.
- Updated `nomic/dataset.py:AtlasProjection.__str__` to use `dataset_link` instead of `map_link`.
- Updated docstring of `nomic/dataset.py:AtlasDataset.create_index` to reflect the change in return value description.
- Incremented version in `setup.py` from `3.0.34` to `3.0.35`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->