### PR TITLE
Change CLI map link to dataset link

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1245,7 +1245,7 @@ class AtlasDataset(AtlasClass):
             logger.warning("Could not find a map being built for this dataset.")
         else:
             logger.info(
-                f"Created map `{atlas_projection.name}` in dataset `{self.identifier}`: {atlas_projection.map_link}"
+                f"Created map `{atlas_projection.name}` in dataset `{self.identifier}`: {atlas_projection.dataset_link}"
             )
         return atlas_projection
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ description = "The official Nomic python client."
 
 setup(
     name="nomic",
-    version="3.0.36",
+    version="3.0.37",
     url="https://github.com/nomic-ai/nomic",
     description=description,
     long_description=description,

--- a/tests/test_atlas_client.py
+++ b/tests/test_atlas_client.py
@@ -313,7 +313,7 @@ def test_map_embeddings():
 
     num_tries = 0
     while map.dataset.is_locked:
-        time.sleep(10)
+        time.sleep(30)
         num_tries += 1
         if num_tries > 10:
             raise TimeoutError('Timed out while waiting for project to unlock')

--- a/tests/test_atlas_client.py
+++ b/tests/test_atlas_client.py
@@ -315,7 +315,7 @@ def test_map_embeddings():
     while map.dataset.is_locked:
         time.sleep(10)
         num_tries += 1
-        if num_tries > 5:
+        if num_tries > 10:
             raise TimeoutError('Timed out while waiting for project to unlock')
 
     retrieved_embeddings = map.embeddings.latent


### PR DESCRIPTION
When a map is newly created from Python, we print the link to the map to the CLI. Seconds after creation, the map is almost never ready, and for a while we've relied on a redirect back to the dataset page. This has proven somewhat inconsistent. Instead, we should just link to the dataset page, where the user can see the current status of their map.
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6fe48ff36781ff4210df96e637fc2bc7a9f2e4f7  | 
|--------|--------|

### Summary:
Changed log message to use dataset link instead of map link, updated version in setup.py, and increased retry limit in test case.

**Key points**:
- Updated `nomic/dataset.py`.
- Modified `nomic/dataset.py::AtlasDataset::create_index` to log dataset link instead of map link.
- Changed log message to use `atlas_projection.dataset_link` instead of `atlas_projection.map_link`.
- Updated version in `setup.py` from `3.0.36` to `3.0.37`.
- Increased retry limit in `tests/test_atlas_client.py::test_map_embeddings` from 5 to 10.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->