### PR TITLE
fix: topic label field default to indexed field if not supplied

### DIFF
--- a/examples/map_text.py
+++ b/examples/map_text.py
@@ -1,4 +1,4 @@
-from nomic import atlas
+from nomic import atlas, AtlasDataset
 import numpy as np
 from datasets import load_dataset
 
@@ -7,12 +7,21 @@ dataset = load_dataset('ag_news')['train']
 max_documents = 100000
 subset_idxs = np.random.choice(len(dataset), size=max_documents, replace=False).tolist()
 documents = [dataset[i] for i in subset_idxs]
+documents = [{'id': i, 'text': doc['text']} for i, doc in enumerate(documents)]
 
-project = atlas.map_data(data=documents,
-                          indexed_field='text',
-                          identifier='News 100k Example',
-                          description='News 100k Example from the ag_news dataset hosted on huggingface.'
-                          )
-print(project.maps)
+dataset = AtlasDataset(identifier="nomic/test-ag-news", unique_id_field='id')
+
+for start in range(0, len(documents), 10000):
+    dataset.add_data(documents[start:start+10000])
+
+dataset.create_index(indexed_field='text')
+
+
+# project = atlas.map_data(data=documents,
+#                           indexed_field='text',
+#                           identifier='News 100k Example',
+#                           description='News 100k Example from the ag_news dataset hosted on huggingface.'
+#                           )
+# print(project.maps)
 
 

--- a/examples/map_text.py
+++ b/examples/map_text.py
@@ -1,4 +1,4 @@
-from nomic import atlas, AtlasDataset
+from nomic import atlas
 import numpy as np
 from datasets import load_dataset
 
@@ -7,21 +7,12 @@ dataset = load_dataset('ag_news')['train']
 max_documents = 100000
 subset_idxs = np.random.choice(len(dataset), size=max_documents, replace=False).tolist()
 documents = [dataset[i] for i in subset_idxs]
-documents = [{'id': i, 'text': doc['text']} for i, doc in enumerate(documents)]
 
-dataset = AtlasDataset(identifier="nomic/test-ag-news", unique_id_field='id')
-
-for start in range(0, len(documents), 10000):
-    dataset.add_data(documents[start:start+10000])
-
-dataset.create_index(indexed_field='text')
-
-
-# project = atlas.map_data(data=documents,
-#                           indexed_field='text',
-#                           identifier='News 100k Example',
-#                           description='News 100k Example from the ag_news dataset hosted on huggingface.'
-#                           )
-# print(project.maps)
+project = atlas.map_data(data=documents,
+                          indexed_field='text',
+                          identifier='News 100k Example',
+                          description='News 100k Example from the ag_news dataset hosted on huggingface.'
+                          )
+print(project.maps)
 
 

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1169,7 +1169,7 @@ class AtlasDataset(AtlasClass):
                     topic_model.build_topic_model = False
                 else:
                     topic_field = (
-                        topic_model.topic_label_field if topic_field.topic_label_field != indexed_field else None
+                        topic_model.topic_label_field if topic_model.topic_label_field != indexed_field else None
                     )
             else:
                 topic_field = topic_model.topic_label_field

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1064,7 +1064,7 @@ class AtlasDataset(AtlasClass):
         elif isinstance(topic_model, NomicTopicOptions):
             pass
         elif topic_model:
-            topic_model = NomicTopicOptions()
+            topic_model = NomicTopicOptions(topic_label_field=indexed_field)
         else:
             topic_model = NomicTopicOptions(build_topic_model=False)
 
@@ -1168,7 +1168,9 @@ class AtlasDataset(AtlasClass):
                     topic_field = None
                     topic_model.build_topic_model = False
                 else:
-                    topic_field = topic_model.topic_label_field
+                    topic_field = (
+                        topic_model.topic_label_field if topic_field.topic_label_field != indexed_field else None
+                    )
             else:
                 topic_field = topic_model.topic_label_field
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ description = "The official Nomic python client."
 
 setup(
     name="nomic",
-    version="3.0.38",
+    version="3.0.39",
     url="https://github.com/nomic-ai/nomic",
     description=description,
     long_description=description,


### PR DESCRIPTION
from changes: https://github.com/nomic-ai/nomic/blame/main/nomic/dataset.py#L1173
Defaulted to using `topic_label_field` but if `NomicTopicOptions` was created with no overrides, the `topic_label_field` is None. Set to `indexed_field` by default if not overridden and also handles case of image topic label field
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit cb3b8d66a1a9a62cdf244aef46c52029285aa887  | 
|--------|--------|

### Summary:
Default `topic_label_field` to `indexed_field` if not provided and handle image topic label field case in `AtlasDataset.create_index` method.

**Key points**:
- Default `topic_label_field` to `indexed_field` if not provided in `nomic/dataset.py` `AtlasDataset.create_index`.
- Handle image topic label field case in `nomic/dataset.py` `AtlasDataset.create_index`.
- Update `examples/map_text.py` to reflect changes in `AtlasDataset` usage.
- Increment version to `3.0.39` in `setup.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->