### PR TITLE
fix: respect modality in create_index

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1086,6 +1086,9 @@ class AtlasDataset(AtlasClass):
         else:
             embedding_model = NomicEmbedOptions()
 
+        if modality is None:
+            modality = self.meta["modality"]
+
         colorable_fields = []
 
         for field in self.dataset_fields:
@@ -1093,7 +1096,7 @@ class AtlasDataset(AtlasClass):
                 colorable_fields.append(field)
 
         build_template = {}
-        if self.modality == "embedding":
+        if modality == "embedding":
             if topic_model.topic_label_field is None:
                 logger.warning(
                     "You did not specify the `topic_label_field` option in your topic_model, your dataset will not contain auto-labeled topics."
@@ -1135,7 +1138,7 @@ class AtlasDataset(AtlasClass):
                 ),
             }
 
-        elif self.modality == "text" or self.modality == "image":
+        elif modality == "text" or modality == "image":
             # find the index id of the index with name reuse_embeddings_from_index
             reuse_embedding_from_index_id = None
             indices = self.indices
@@ -1149,10 +1152,10 @@ class AtlasDataset(AtlasClass):
                         f"Could not find the index '{reuse_embeddings_from_index}' to re-use from. Possible options are {[index.name for index in indices]}"
                     )
 
-            if indexed_field is None and self.modality == "text":
+            if indexed_field is None and modality == "text":
                 raise Exception("You did not specify a field to index. Specify an 'indexed_field'.")
 
-            if self.modality == "image":
+            if modality == "image":
                 indexed_field = "_blob_hash"
                 if indexed_field is not None:
                     logger.warning("Ignoring indexed_field for image datasets. Only _blob_hash is supported.")
@@ -1160,7 +1163,7 @@ class AtlasDataset(AtlasClass):
             if indexed_field not in self.dataset_fields:
                 raise Exception(f"Indexing on {indexed_field} not allowed. Valid options are: {self.dataset_fields}")
 
-            if self.modality == "image":
+            if modality == "image":
                 if topic_model.topic_label_field is None:
                     print(
                         "You did not specify the `topic_label_field` option in your topic_model, your dataset will not contain auto-labeled topics."

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ description = "The official Nomic python client."
 
 setup(
     name="nomic",
-    version="3.0.39",
+    version="3.0.40",
     url="https://github.com/nomic-ai/nomic",
     description=description,
     long_description=description,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ec6c4e963dcd0e008ca6d3f63ff5a52cfd2bed95  | 
|--------|--------|

### Summary:
Fixes `create_index` in `nomic/dataset.py` to respect the `modality` parameter, defaulting to the dataset's modality if not provided, and updates the version in `setup.py`.

**Key points**:
- **Modified** `nomic/dataset.py`:
  - **Function**: `nomic.dataset.AtlasDataset.create_index`
    - Added check to default `modality` to `self.meta['modality']` if `modality` is `None`.
    - Replaced `self.modality` with `modality` in conditional checks.
- **Updated** `setup.py`:
  - Bumped version from `3.0.39` to `3.0.40`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->