### PR TITLE
docs: update docs to make more clear that blobs are stored locally only

### DIFF
--- a/nomic/atlas.py
+++ b/nomic/atlas.py
@@ -38,7 +38,7 @@ def map_data(
 
     Args:
         data: An ordered collection of the datapoints you are structuring. Can be a list of dictionaries, Pandas Dataframe or PyArrow Table.
-        blobs: A list of image paths, bytes, or PIL images to add to your image dataset.
+        blobs: A list of image paths, bytes, or PIL images to add to your image dataset that are stored locally.
         embeddings: An [N,d] numpy array containing the N embeddings to add.
         identifier: A name for your dataset that is used to generate the dataset identifier. A unique name will be chosen if not supplied.
         description: The description of your dataset

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1356,7 +1356,7 @@ class AtlasDataset(AtlasClass):
         Args:
             data: A pandas DataFrame, list of dictionaries, or pyarrow Table matching the dataset schema.
             embeddings: A numpy array of embeddings: each row corresponds to a row in the table. Use if you already have embeddings for your datapoints.
-            blobs: A list of image paths, bytes, or PIL Images. Use if you want to add images to your dataset.
+            blobs: A list of image paths, bytes, or PIL Images. Use if you want to create an AtlasDataset using image embeddings over your images.
             pbar: (Optional). A tqdm progress bar to update.
         """
         if embeddings is not None:

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1356,7 +1356,7 @@ class AtlasDataset(AtlasClass):
         Args:
             data: A pandas DataFrame, list of dictionaries, or pyarrow Table matching the dataset schema.
             embeddings: A numpy array of embeddings: each row corresponds to a row in the table. Use if you already have embeddings for your datapoints.
-            blobs: A list of image paths, bytes, or PIL Images. Use if you want to create an AtlasDataset using image embeddings over your images.
+            blobs: A list of image paths, bytes, or PIL Images. Use if you want to create an AtlasDataset using image embeddings over your images. Note: Blobs are stored locally only.
             pbar: (Optional). A tqdm progress bar to update.
         """
         if embeddings is not None:

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1356,6 +1356,7 @@ class AtlasDataset(AtlasClass):
         Args:
             data: A pandas DataFrame, list of dictionaries, or pyarrow Table matching the dataset schema.
             embeddings: A numpy array of embeddings: each row corresponds to a row in the table. Use if you already have embeddings for your datapoints.
+            blobs: A list of image paths, bytes, or PIL Images. Use if you want to add images to your dataset.
             pbar: (Optional). A tqdm progress bar to update.
         """
         if embeddings is not None:
@@ -1374,6 +1375,7 @@ class AtlasDataset(AtlasClass):
         """
         Add data, with associated blobs, to the dataset.
         Uploads blobs to the server and associates them with the data.
+        Blobs must reference objects stored locally
         """
         if isinstance(data, DataFrame):
             data = pa.Table.from_pandas(data)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ description = "The official Nomic python client."
 
 setup(
     name="nomic",
-    version="3.0.40",
+    version="3.0.41",
     url="https://github.com/nomic-ai/nomic",
     description=description,
     long_description=description,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9f7363ba81a358a48a57691a87bd4255ebad4148  | 
|--------|--------|

### Summary:
Clarified documentation to specify that blobs are stored locally, added details about blobs for AtlasDataset, and incremented the version to 3.0.41.

**Key points**:
- **Updated** `nomic/atlas.py`:
  - `map_data` function: Clarified that blobs are stored locally.
- **Updated** `nomic/dataset.py`:
  - `add_data` function: Added description for `blobs` parameter and clarified that blobs are used for creating AtlasDataset with image embeddings.
  - `_add_blobs` function: Clarified that blobs must reference objects stored locally.
- **Updated** `setup.py`:
  - Incremented version from `3.0.40` to `3.0.41`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->