### PR TITLE
feat: sagemaker client updates for batched image

### DIFF
--- a/nomic/aws/sagemaker.py
+++ b/nomic/aws/sagemaker.py
@@ -190,7 +190,7 @@ def embed_text(
 # only way I could get sagemaker with multipart to work
 def prepare_multipart_request(images: List[Tuple[str, bytes]]) -> Tuple[bytes, bytes]:
     # Prepare the multipart body
-    boundary = b"---------------------------" + str(hash(tuple(images))).encode("utf-8")
+    boundary = b"---------------------------Boundary"
     body = b""
     for i, (name, img_bytes) in enumerate(images):
         body += b"--" + boundary + b"\r\n"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ description = "The official Nomic python client."
 
 setup(
     name="nomic",
-    version="3.0.41",
+    version="3.0.42",
     url="https://github.com/nomic-ai/nomic",
     description=description,
     long_description=description,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c14465ee987b8240c082892c4a6ea9aca1c28f0a  | 
|--------|--------|

### Summary:
Updated SageMaker client to handle batched image requests using multipart/form-data and modified instance type in batch transform.

**Key points**:
- Updated `nomic/aws/sagemaker.py` to handle batched image requests using multipart/form-data.
- Added `nomic/aws/sagemaker.py::prepare_multipart_request` to prepare multipart body for image requests.
- Modified `nomic/aws/sagemaker.py::preprocess_image` to return multipart body and boundary.
- Updated `nomic/aws/sagemaker.py::sagemaker_image_request` to use multipart/form-data content type.
- Changed `nomic/aws/sagemaker.py::embed_image` to process images in batches.
- Updated instance type in `nomic/aws/sagemaker.py::batch_transform_image` to `ml.g4dn.xlarge`.
- Bumped version in `setup.py` from `3.0.41` to `3.0.42`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->