### PR TITLE
fix: move indexed_field check earlier for image dataset

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1089,6 +1089,11 @@ class AtlasDataset(AtlasClass):
         if modality is None:
             modality = self.meta["modality"]
 
+        if modality == "image":
+            indexed_field = "_blob_hash"
+            if indexed_field is not None:
+                logger.warning("Ignoring indexed_field for image datasets. Only _blob_hash is supported.")
+
         colorable_fields = []
 
         for field in self.dataset_fields:
@@ -1154,11 +1159,6 @@ class AtlasDataset(AtlasClass):
 
             if indexed_field is None and modality == "text":
                 raise Exception("You did not specify a field to index. Specify an 'indexed_field'.")
-
-            if modality == "image":
-                indexed_field = "_blob_hash"
-                if indexed_field is not None:
-                    logger.warning("Ignoring indexed_field for image datasets. Only _blob_hash is supported.")
 
             if indexed_field not in self.dataset_fields:
                 raise Exception(f"Indexing on {indexed_field} not allowed. Valid options are: {self.dataset_fields}")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ description = "The official Nomic python client."
 
 setup(
     name="nomic",
-    version="3.0.42",
+    version="3.0.43",
     url="https://github.com/nomic-ai/nomic",
     description=description,
     long_description=description,


### PR DESCRIPTION
we ignore `indexed_field` for image datasets but if passed and not overwritten before, we'd accidentally ignore the colorable field. This fixes NOM-1782
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d8b8c0124bcf65da6036ee9bdee22c48ebe0276c  | 
|--------|--------|

### Summary:
Moved `indexed_field` check earlier in `AtlasDataset.create_index` to ensure correct handling for image datasets and updated version in `setup.py`.

**Key points**:
- Moved `indexed_field` check earlier in `nomic/dataset.py::AtlasDataset::create_index`.
- Ensures `indexed_field` is set to `_blob_hash` before other operations for image datasets.
- Prevents accidental ignoring of the colorable field.
- Added a warning log if `indexed_field` is ignored for image datasets.
- Updated version in `setup.py` from `3.0.42` to `3.0.43`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->