### PR TITLE
override default organization for enterprise users

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -128,7 +128,7 @@ class AtlasClass(object):
         user = self._get_current_user()
 
         for organization in user["organizations"]:
-            if organization["plan_type"] == "enterprise":
+            if organization.get("plan_type") and organization.get("plan_type") == "enterprise":
                 return organization
 
         if user["default_organization"]:

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -126,11 +126,11 @@ class AtlasClass(object):
         """
 
         user = self._get_current_user()
-        
+
         for organization in user["organizations"]:
             if organization["plan_type"] == "enterprise":
                 return organization
-        
+
         if user["default_organization"]:
             for organization in user["organizations"]:
                 if organization["organization_id"] == user["default_organization"]:

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -126,6 +126,14 @@ class AtlasClass(object):
         """
 
         user = self._get_current_user()
+        
+        # first check to see whether user has membership to any enterprise organizations 
+        # if so, override the default organization with the first one that is found
+        for organization in user["organizations"]:
+            if organization["plan_type"] == "enterprise":
+                return organization
+        
+        # if no enterprise organization is found, then use the standard default organization
         if user["default_organization"]:
             for organization in user["organizations"]:
                 if organization["organization_id"] == user["default_organization"]:

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -127,13 +127,10 @@ class AtlasClass(object):
 
         user = self._get_current_user()
         
-        # first check to see whether user has membership to any enterprise organizations 
-        # if so, override the default organization with the first one that is found
         for organization in user["organizations"]:
             if organization["plan_type"] == "enterprise":
                 return organization
         
-        # if no enterprise organization is found, then use the standard default organization
         if user["default_organization"]:
             for organization in user["organizations"]:
                 if organization["organization_id"] == user["default_organization"]:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ description = "The official Nomic python client."
 
 setup(
     name="nomic",
-    version="3.0.44",
+    version="3.0.45",
     url="https://github.com/nomic-ai/nomic",
     description=description,
     long_description=description,


### PR DESCRIPTION
check to see whether user has membership to any enterprise organizations. if so, override the default organization with the first enterprise organization for which they are a member

https://linear.app/nomic/issue/NOM-1764/atlas-python-client-make-users-default-organization-set-to-first
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b00bce23a2e71181751e063bf591fa219544797d  | 
|--------|--------|

### Summary:
Added a check to set the default organization to the first enterprise organization if the user is a member of any, and updated version to `3.0.45`.

**Key points**:
- Added a check to set the default organization to the first enterprise organization if the user is a member of any.
- Updated version to `3.0.45`.
- **File Modified**: `nomic/dataset.py`, `setup.py`
- **Function Modified**: `nomic/dataset.py::AtlasClass::_get_current_users_main_organization`
- **Change**: Added a check to see if the user has membership in any enterprise organizations.
- **Behavior**: If the user is a member of any enterprise organization, the default organization is overridden with the first enterprise organization found.
- **Fallback**: If no enterprise organization is found, the standard default organization is used.
- **Version Bump**: Updated `setup.py` version from `3.0.44` to `3.0.45`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->