### PR TITLE
fix: release-please releases twice, check if commit message is chore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,13 +80,20 @@ jobs:
       - image: cimg/node:20.2.0
     steps:
       - checkout
-      - run: |
-          npx release-please release-pr \
-            --token $GITHUB_TOKEN \
-            --repo-url $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
-            --target-branch $CIRCLE_BRANCH \
-            --config-file .circleci/release/release-please-config.json \
-            --manifest-file .circleci/release/.release-please-manifest.json
+      - run:
+          name: Check commit message and run release-please if not a release commit
+          command: |
+            COMMIT_MSG=$(git log -1 --pretty=%B)
+            if [[ "$COMMIT_MSG" != "chore(main): release"* && "$COMMIT_MSG" != "chore: release"* ]]; then
+              npx release-please release-pr \
+                --token $GITHUB_TOKEN \
+                --repo-url $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
+                --target-branch $CIRCLE_BRANCH \
+                --config-file .circleci/release/release-please-config.json \
+                --manifest-file .circleci/release/.release-please-manifest.json
+            else
+              echo "Skipping release-please as this is a release commit"
+            fi
 
   github-release:
     docker:


### PR DESCRIPTION
fixes double release on v3.1.0: https://github.com/nomic-ai/nomic/pull/331
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3b33e2509658e3abf3c4b64c20f804ed469789c1  | 
|--------|--------|

### Summary:
Fixes double release issue by adding a commit message check in `.circleci/config.yml`.

**Key points**:
- Updated `.circleci/config.yml` to prevent double releases.
- Added a check in `jobs/release-pr/steps/run` to skip `release-please` if the commit message starts with `chore(main): release` or `chore: release`.
- Ensures `release-please` only runs for non-release commits.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->