### PR TITLE
fix: upload failure due to non-rgb image

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1409,9 +1409,10 @@ class AtlasDataset(AtlasClass):
         # TODO: add support for other modalities
         images = []
         for uuid, blob in tqdm(zip(ids, blobs), total=len(ids), desc="Loading images"):
-            if isinstance(blob, str) and os.path.exists(blob):
+            if (isinstance(blob, str) or isinstance(blob, Path)) and os.path.exists(blob):
                 # Auto resize to max 512x512
                 image = Image.open(blob)
+                image = image.convert("RGB")
                 if image.height > 512 or image.width > 512:
                     image = image.resize((512, 512))
                 buffered = BytesIO()

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1409,7 +1409,7 @@ class AtlasDataset(AtlasClass):
         # TODO: add support for other modalities
         images = []
         for uuid, blob in tqdm(zip(ids, blobs), total=len(ids), desc="Loading images"):
-            if Path(blob).exists():
+            if (isinstance(blob, str) or isinstance(blob, Path)) and os.path.exists(blob):
                 # Auto resize to max 512x512
                 image = Image.open(blob)
                 image = image.convert("RGB")
@@ -1421,7 +1421,7 @@ class AtlasDataset(AtlasClass):
             elif isinstance(blob, bytes):
                 images.append((uuid, blob))
             elif isinstance(blob, Image.Image):
-                blob = blob.convert("RGB")  # type: ignore
+                blob = blob.convert("RGB") # type: ignore
                 if blob.height > 512 or blob.width > 512:
                     blob = blob.resize((512, 512))
                 buffered = BytesIO()

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1421,6 +1421,7 @@ class AtlasDataset(AtlasClass):
             elif isinstance(blob, bytes):
                 images.append((uuid, blob))
             elif isinstance(blob, Image.Image):
+                image = image.convert("RGB")
                 if blob.height > 512 or blob.width > 512:
                     blob = blob.resize((512, 512))
                 buffered = BytesIO()

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1409,7 +1409,7 @@ class AtlasDataset(AtlasClass):
         # TODO: add support for other modalities
         images = []
         for uuid, blob in tqdm(zip(ids, blobs), total=len(ids), desc="Loading images"):
-            if (isinstance(blob, str) or isinstance(blob, Path)) and os.path.exists(blob):
+            if Path(blob).exists():
                 # Auto resize to max 512x512
                 image = Image.open(blob)
                 image = image.convert("RGB")
@@ -1421,7 +1421,7 @@ class AtlasDataset(AtlasClass):
             elif isinstance(blob, bytes):
                 images.append((uuid, blob))
             elif isinstance(blob, Image.Image):
-                image = image.convert("RGB")
+                image = image.convert("RGB") # type: ignore
                 if blob.height > 512 or blob.width > 512:
                     blob = blob.resize((512, 512))
                 buffered = BytesIO()

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1421,7 +1421,7 @@ class AtlasDataset(AtlasClass):
             elif isinstance(blob, bytes):
                 images.append((uuid, blob))
             elif isinstance(blob, Image.Image):
-                blob = blob.convert("RGB") # type: ignore
+                blob = blob.convert("RGB")  # type: ignore
                 if blob.height > 512 or blob.width > 512:
                     blob = blob.resize((512, 512))
                 buffered = BytesIO()

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1421,7 +1421,7 @@ class AtlasDataset(AtlasClass):
             elif isinstance(blob, bytes):
                 images.append((uuid, blob))
             elif isinstance(blob, Image.Image):
-                image = image.convert("RGB") # type: ignore
+                blob = blob.convert("RGB")  # type: ignore
                 if blob.height > 512 or blob.width > 512:
                     blob = blob.resize((512, 512))
                 buffered = BytesIO()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b5c4e673bc222663d3b60a229e9d90618a04f96c  | 
|--------|--------|

### Summary:
Fixes image upload failures by converting non-RGB images to RGB format in `nomic/dataset.py`.

**Key points**:
- Fixes image upload failures in `nomic/dataset.py`.
- Converts non-RGB images to RGB format in the `_add_blobs` function.
- Ensures all images are in RGB format to prevent upload failures.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->