### PR TITLE
fix: task type sagemaker

### DIFF
--- a/examples/sagemaker/run-nomic-embed-text.ipynb
+++ b/examples/sagemaker/run-nomic-embed-text.ipynb
@@ -145,7 +145,7 @@
     }
    ],
    "source": [
-    "response = embed_text(texts, endpoint_name, region_name=region_name, batch_size=32, dimensionality=128)\n",
+    "response = embed_text(texts, endpoint_name, region_name=region_name, batch_size=32, dimensionality=128, task_type=\"search_document\")\n",
     "embeddings = response[\"embeddings\"]\n",
     "np.array(embeddings).shape"
    ]

--- a/nomic/aws/sagemaker.py
+++ b/nomic/aws/sagemaker.py
@@ -38,7 +38,6 @@ def parse_sagemaker_response(response):
     return resp["embeddings"]
 
 
-
 def batch_transform_text(
     s3_input_path: str,
     s3_output_path: str,
@@ -138,7 +137,6 @@ def embed_text(
         logger.warning("No texts to embed.")
         return None
 
-        
     assert task_type in [
         "search_query",
         "search_document",

--- a/nomic/aws/sagemaker.py
+++ b/nomic/aws/sagemaker.py
@@ -38,25 +38,6 @@ def parse_sagemaker_response(response):
     return resp["embeddings"]
 
 
-def preprocess_texts(texts: List[str], task_type: str = "search_document"):
-    """
-    Preprocess a list of texts for embedding using a sagemaker model.
-
-    Args:
-        texts: List of texts to be embedded.
-        task_type: The task type to use when embedding. One of `search_query`, `search_document`, `classification`, `clustering`
-
-    Returns:
-        List of texts formatted for sagemaker embedding.
-    """
-    assert task_type in [
-        "search_query",
-        "search_document",
-        "classification",
-        "clustering",
-    ], f"Invalid task type: {task_type}"
-    return [f"{task_type}: {text}" for text in texts]
-
 
 def batch_transform_text(
     s3_input_path: str,
@@ -157,7 +138,14 @@ def embed_text(
         logger.warning("No texts to embed.")
         return None
 
-    texts = preprocess_texts(texts, task_type)
+        
+    assert task_type in [
+        "search_query",
+        "search_document",
+        "classification",
+        "clustering",
+    ], f"Invalid task type: {task_type}"
+
     assert dimensionality in (
         64,
         128,
@@ -175,6 +163,7 @@ def embed_text(
                 "texts": texts[i : i + batch_size],
                 "binary": binary,
                 "dimensionality": dimensionality,
+                "task_type": task_type,
             }
         )
         response = client.invoke_endpoint(EndpointName=sagemaker_endpoint, Body=batch, ContentType="application/json")

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             "pylint",
             "pytest",
             "isort",
-            "pyright",
+            "pyright<=pyright-1.1.377",
             "myst-parser",
             "mkdocs-material",
             "mkautodoc",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             "pylint",
             "pytest",
             "isort",
-            "pyright<=pyright-1.1.377",
+            "pyright<=1.1.377",
             "myst-parser",
             "mkdocs-material",
             "mkautodoc",


### PR DESCRIPTION
task type is now part of the request body in the sagemaker image
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removed `preprocess_texts` and integrated task type validation into `embed_text` in `sagemaker.py`, with task type now part of the request body.
> 
>   - **Functionality**:
>     - Removed `preprocess_texts` function from `sagemaker.py`.
>     - Integrated task type validation directly into `embed_text` function.
>   - **Behavior**:
>     - `embed_text` now directly asserts valid `task_type` values: `search_query`, `search_document`, `classification`, `clustering`.
>     - Removed text preprocessing step that prefixed texts with task type.
>     - Task type is now part of the request body in `embed_text`.
>   - **Misc**:
>     - Updated `pyright` version constraint in `setup.py` to `<=pyright-1.1.377`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for 91b59e0e9a21e137d662997b5a0638870ace8b8c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->