### PR TITLE
fix: load readme as long description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,15 @@ from setuptools import setup, find_packages
 
 description = "The official Nomic python client."
 
+with open("README.md") as f:
+    long_description = f.read()
+
 setup(
     name="nomic",
     version="3.3.0",
     url="https://github.com/nomic-ai/nomic",
     description=description,
-    long_description=description,
+    long_description=long_description,
     packages=find_packages(include=["nomic", "nomic.*"]),
     author_email="support@nomic.ai",
     author="nomic.ai",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Load `long_description` from `README.md` and bump version to 3.3.1 in `setup.py`.
> 
>   - **Setup Configuration**:
>     - Load `long_description` from `README.md` in `setup.py` instead of using `description`.
>   - **Version Update**:
>     - Bump version from `3.3.0` to `3.3.1` in `setup.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for 78c350044975d20cab156d6b5dbf828da3117f5d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->