### PR TITLE
fix: prevent autogenerated __index_level_0__ column uploading pandas dataframes

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -10,13 +10,11 @@ from datetime import datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
-import sys
 
 import numpy as np
 import pyarrow as pa
 import requests
 from loguru import logger
-import pandas
 from pandas import DataFrame
 from PIL import Image
 from pyarrow import compute as pc

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1377,7 +1377,7 @@ class AtlasDataset(AtlasClass):
         if isinstance(data, DataFrame):
             cols_before = set(data.columns)
             for col in cols_before:
-                if col.starts_with("_"):
+                if col.startswith("_"):
                     raise ValueError(
                         f"You are attempting to upload a pandas dataframe with the column name {col}, but columns beginning with '_' are reserved for Atlas internal use. Please rename your column and try again."
                     )

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -12,10 +12,10 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
+import pandas as pd
 import pyarrow as pa
 import requests
 from loguru import logger
-import pandas as pd
 from pandas import DataFrame
 from PIL import Image
 from pyarrow import compute as pc
@@ -1374,7 +1374,7 @@ class AtlasDataset(AtlasClass):
             blobs: A list of image paths, bytes, or PIL Images. Use if you want to create an AtlasDataset using image embeddings over your images. Note: Blobs are stored locally only.
             pbar: (Optional). A tqdm progress bar to update.
         """
-        if isinstance(data, pd.DataFrame):
+        if isinstance(data, DataFrame):
             cols_before = set(data.columns)
             for col in cols_before:
                 if col.starts_with("_"):

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1373,6 +1373,12 @@ class AtlasDataset(AtlasClass):
             blobs: A list of image paths, bytes, or PIL Images. Use if you want to create an AtlasDataset using image embeddings over your images. Note: Blobs are stored locally only.
             pbar: (Optional). A tqdm progress bar to update.
         """
+        if isinstance(data, DataFrame):
+            logger.info(
+                "DataFrame index was reset with pandas.DataFrame.reset_index() during upload to Atlas"
+            )
+            data = data.reset_index()
+
         if embeddings is not None:
             self._add_embeddings(data=data, embeddings=embeddings, pbar=pbar)
         elif isinstance(data, pa.Table) and "_embeddings" in data.column_names:  # type: ignore
@@ -1520,10 +1526,7 @@ class AtlasDataset(AtlasClass):
         tb: pa.Table
 
         if isinstance(data, DataFrame):
-            logger.info(
-                "DataFrame index was reset with pandas.DataFrame.reset_index() when uploading to Atlas"
-            )
-            tb = pa.Table.from_pandas(data.reset_index())
+            tb = pa.Table.from_pandas(data)
         elif isinstance(data, list):
             tb = pa.Table.from_pylist(data)
         elif isinstance(data, pa.Table):

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1520,10 +1520,10 @@ class AtlasDataset(AtlasClass):
         tb: pa.Table
 
         if isinstance(data, DataFrame):
-            logger.warning(
-                "Note: converting your data from Pandas DataFrame to PyArrow table means its index was reset"
+            logger.info(
+                "DataFrame index was reset with pandas.DataFrame.reset_index() when uploading to Atlas"
             )
-            tb = pa.Table.from_pandas(data, preserve_index=False)
+            tb = pa.Table.from_pandas(data.reset_index())
         elif isinstance(data, list):
             tb = pa.Table.from_pylist(data)
         elif isinstance(data, pa.Table):

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -10,11 +10,13 @@ from datetime import datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
+import sys
 
 import numpy as np
 import pyarrow as pa
 import requests
 from loguru import logger
+import pandas
 from pandas import DataFrame
 from PIL import Image
 from pyarrow import compute as pc
@@ -1520,7 +1522,10 @@ class AtlasDataset(AtlasClass):
         tb: pa.Table
 
         if isinstance(data, DataFrame):
-            tb = pa.Table.from_pandas(data)
+            logger.warning(
+                "Note: converting your data from Pandas DataFrame to PyArrow table means its index was reset"
+            )
+            tb = pa.Table.from_pandas(data, preserve_index=False)
         elif isinstance(data, list):
             tb = pa.Table.from_pylist(data)
         elif isinstance(data, pa.Table):

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1378,7 +1378,9 @@ class AtlasDataset(AtlasClass):
             cols_before = set(data.columns)
             for col in cols_before:
                 if col.starts_with("_"):
-                    raise ValueError(f"You are attempting to upload a pandas dataframe with the column name {col}, but columns beginning with '_' are reserved for Atlas internal use. Please rename your column and try again.")
+                    raise ValueError(
+                        f"You are attempting to upload a pandas dataframe with the column name {col}, but columns beginning with '_' are reserved for Atlas internal use. Please rename your column and try again."
+                    )
             data = pa.Table.from_pandas(data)
             for newcol in set(data.column_names).difference(cols_before):
                 logger.warning(f"Dropping column {newcol} added in pandas conversion to pyarrow")

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1374,9 +1374,7 @@ class AtlasDataset(AtlasClass):
             pbar: (Optional). A tqdm progress bar to update.
         """
         if isinstance(data, DataFrame):
-            logger.info(
-                "DataFrame index was reset with pandas.DataFrame.reset_index() during upload to Atlas"
-            )
+            logger.info("DataFrame index was reset with pandas.DataFrame.reset_index() during upload to Atlas")
             data = data.reset_index()
 
         if embeddings is not None:


### PR DESCRIPTION
Need to prevent the column name `__index_level_0__` from being auto-generated when a user uploads dataframe

In response to this problem from a user on discord:
- https://discord.com/channels/1076964370942267462/1076964911034400830/1305934851068792852
