### PR TITLE
Use concurrent thread pool to download sidecar items

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -664,7 +664,7 @@ class AtlasProjection:
         sidecar_suffix = "feather"
         if sidecar_name != "":
             sidecar_suffix = f"{sidecar_name}.feather"
-        with concurrent.futures.ThreadPoolExecutor(16) as ex:
+        with concurrent.futures.ThreadPoolExecutor(4) as ex:
             futures = []
             for key in tqdm(self._manifest["key"].to_pylist()):
                 sidecar_path = self.tile_destination / f"{key}.{sidecar_suffix}"

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -672,7 +672,11 @@ class AtlasProjection:
                     self.dataset.atlas_api_path
                     + f"/v1/project/{self.dataset.id}/index/projection/{self.id}/quadtree/{key}.{sidecar_suffix}"
                 )
-                futures.append(ex.submit(download_feather, sidecar_url, sidecar_path, headers=self.dataset.header, overwrite=overwrite))
+                futures.append(
+                    ex.submit(
+                        download_feather, sidecar_url, sidecar_path, headers=self.dataset.header, overwrite=overwrite
+                    )
+                )
                 downloaded_files.append(sidecar_path)
             for f in futures:
                 f.result()


### PR DESCRIPTION
Currently, our client downloads sidecar files sequentially, which is slow when there are a lot of large sidecar files. Even if they're small, using a thread pool can reduce the time spent waiting for connections and HTTP responses.

I'm using a default of 16 for reasonable concurrency without hitting rate limits or overloading the client.

There are places where we have multiple calls to _download_sidecar. Future optimization might include running those concurrently using the same shared thread pool.

A quick test (cache cleared between tests):

# Before

2024-12-02 19:52:18.968 | INFO     | nomic.dataset:__init__:782 - Loading existing dataset `wilsonlin/***`.
2024-12-02 19:52:20.225 | INFO     | nomic.data_operations:_download_latent:550 - Downloading latent embeddings
Downloading 21 without thread pool
Downloaded 21 in 40.9260950088501 sec

# After

2024-12-02 19:53:40.570 | INFO     | nomic.dataset:__init__:782 - Loading existing dataset `wilsonlin/***`.
2024-12-02 19:53:41.455 | INFO     | nomic.data_operations:_download_latent:550 - Downloading latent embeddings
Using thread pool to download 21
Downloaded 21 in 1.3499267101287842 sec
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Use `ThreadPoolExecutor` in `_download_sidecar()` in `nomic/dataset.py` to download sidecar files concurrently, reducing download time significantly.
> 
>   - **Behavior**:
>     - Use `concurrent.futures.ThreadPoolExecutor` in `_download_sidecar()` in `nomic/dataset.py` to download sidecar files concurrently.
>     - Default thread pool size is 16 to balance concurrency and avoid rate limits.
>   - **Performance**:
>     - Reduces download time from 40.9 seconds to 1.35 seconds for 21 sidecar files in test case.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for bc7c30b61188f45fc1b2e7ce741b95583661b26c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->