### PR TITLE
Send User-Agent header on requests and check for warnings in responses

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1,6 +1,7 @@
 import base64
 import concurrent
 import concurrent.futures
+import importlib.metadata
 import io
 import json
 import os
@@ -72,13 +73,23 @@ class AtlasClass(object):
         token = self.credentials["token"]
         self.token = token
 
-        self.header = {"Authorization": f"Bearer {token}"}
+        try:
+            version = importlib.metadata.version("nomic")
+        except Exception:
+            version = "unknown"
+
+        self.header = {
+            "Authorization": f"Bearer {token}",
+            "User-Agent": f"py-nomic/{version}"
+        }
 
         if self.token:
             response = requests.get(
                 self.atlas_api_path + "/v1/user",
                 headers=self.header,
             )
+            if "X-AtlasWarning" in response.headers:
+                logger.warning(response.headers["X-AtlasWarning"])
             response = validate_api_http_response(response)
             if not response.status_code == 200:
                 logger.warning(str(response))

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -78,10 +78,7 @@ class AtlasClass(object):
         except Exception:
             version = "unknown"
 
-        self.header = {
-            "Authorization": f"Bearer {token}",
-            "User-Agent": f"py-nomic/{version}"
-        }
+        self.header = {"Authorization": f"Bearer {token}", "User-Agent": f"py-nomic/{version}"}
 
         if self.token:
             response = requests.get(


### PR DESCRIPTION
This will allow us to identify the Nomic client version, and when necessary send a message specific for that version back to the client.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `User-Agent` header with client version and log `X-AtlasWarning` in `AtlasClass` requests.
> 
>   - **Behavior**:
>     - Adds `User-Agent` header with Nomic client version in requests in `AtlasClass` constructor.
>     - Logs warnings from `X-AtlasWarning` header in responses in `AtlasClass` constructor.
>   - **Imports**:
>     - Adds `importlib.metadata` to retrieve package version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for 576db90282ce357d565b2359ff5d4c30e96ecad6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->