### PR TITLE
Implement faster fail path for large upload batch sizes

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1620,6 +1620,7 @@ class AtlasDataset(AtlasClass):
             close_pbar = True
             pbar = tqdm(total=int(len(data)) // shard_size)
         failed = 0
+        failed_reqs = 0
         succeeded = 0
         errors_504 = 0
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
@@ -1668,6 +1669,11 @@ class AtlasDataset(AtlasClass):
                                 failed += shard_size
                                 pbar.update(1)
                                 response.close()
+                            failed_reqs += 1
+                            if failed_reqs > 10:
+                                raise RuntimeError(
+                                    f"{self.identifier}: Too many upload requests have failed at this time. Please try again later."
+                                )
                     else:
                         # A successful upload.
                         succeeded += shard_size


### PR DESCRIPTION
Use a faster fail path for uploads when 10 batches fail to upload. A high absolute failure count indicates saturation on the server side, and our current ratio-based mechanism will keep hitting our servers in this scenario given a large amount of batches.

The current wider failure handling logic is kept as is as they handle some other scenarios.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a faster fail path in `nomic/dataset.py` for uploads when 10 batches fail, indicating server saturation.
> 
>   - **Behavior**:
>     - Introduces a faster fail path in `send_request()` in `nomic/dataset.py` when 10 upload batches fail, raising a `RuntimeError` to indicate server saturation.
>     - Retains existing failure handling logic for other scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for 1f9e420b690968dda9a9c5c4cbab82835aec8286. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->