### PR TITLE
Normalize dataset slugs before sending request to server side

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -6,12 +6,12 @@ import json
 import os
 import re
 import time
+import unicodedata
 from contextlib import contextmanager
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
-import unicodedata
 
 import numpy as np
 import pandas as pd

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -757,10 +757,10 @@ class AtlasDataset(AtlasClass):
         assert identifier is not None or dataset_id is not None, "You must pass a dataset identifier"
         # Normalize identifier.
         if identifier is not None:
-            identifier = unicodedata.normalize('NFD', identifier)  # normalize accents
-            identifier = identifier.lower().replace(' ', '-').replace('_', '-')
-            identifier = re.sub(r"[^a-z0-9-]", '', identifier)
-            identifier = re.sub(r'-+', '-', identifier)
+            identifier = unicodedata.normalize("NFD", identifier)  # normalize accents
+            identifier = identifier.lower().replace(" ", "-").replace("_", "-")
+            identifier = re.sub(r"[^a-z0-9-]", "", identifier)
+            identifier = re.sub(r"-+", "-", identifier)
 
         super().__init__()
 

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -4,12 +4,14 @@ import concurrent.futures
 import io
 import json
 import os
+import re
 import time
 from contextlib import contextmanager
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
+import unicodedata
 
 import numpy as np
 import pandas as pd
@@ -753,6 +755,12 @@ class AtlasDataset(AtlasClass):
         * **dataset_id** - An alternative way to load a dataset is by passing the dataset_id directly. This only works if a dataset exists.
         """
         assert identifier is not None or dataset_id is not None, "You must pass a dataset identifier"
+        # Normalize identifier.
+        if identifier is not None:
+            identifier = unicodedata.normalize('NFD', identifier)  # normalize accents
+            identifier = identifier.lower().replace(' ', '-').replace('_', '-')
+            identifier = re.sub(r"[^a-z0-9-]", '', identifier)
+            identifier = re.sub(r'-+', '-', identifier)
 
         super().__init__()
 


### PR DESCRIPTION
Currently, our API normalizes the slug name, but the client is unaware of this normalization. This means that if we use a non-normal slug name that does exist normalized, the client will see that it doesn't exist, and try to create it, creating repeated duplicates.

Quick test:

# create.py

```python
from nomic.dataset import AtlasDataset

AtlasDataset("Foo Bar", unique_id_field="id")
```

# Before

```bash
(.venv) @wilson-nomic ➜ /workspaces/nomic (normalize-slug) $ python create.py
2024-12-02 20:39:15.563 | INFO     | nomic.dataset:_create_project:847 - Organization name: `wilsonlin`
2024-12-02 20:39:16.415 | INFO     | nomic.dataset:_create_project:875 - Creating dataset `foo-bar`
(.venv) @wilson-nomic ➜ /workspaces/nomic (normalize-slug) $ python create.py
2024-12-02 20:39:15.563 | INFO     | nomic.dataset:_create_project:847 - Organization name: `wilsonlin`
2024-12-02 20:39:16.415 | INFO     | nomic.dataset:_create_project:875 - Creating dataset `foo-bar-1`
(.venv) @wilson-nomic ➜ /workspaces/nomic (normalize-slug) $ python create.py
2024-12-02 20:39:15.563 | INFO     | nomic.dataset:_create_project:847 - Organization name: `wilsonlin`
2024-12-02 20:39:16.415 | INFO     | nomic.dataset:_create_project:875 - Creating dataset `foo-bar-2`
(.venv) @wilson-nomic ➜ /workspaces/nomic (normalize-slug) $ python create.py
2024-12-02 20:39:15.563 | INFO     | nomic.dataset:_create_project:847 - Organization name: `wilsonlin`
2024-12-02 20:39:16.415 | INFO     | nomic.dataset:_create_project:875 - Creating dataset `foo-bar-3`
```

# After

```bash
(.venv) @wilson-nomic ➜ /workspaces/nomic (normalize-slug) $ python create.py
2024-12-02 20:40:41.596 | INFO     | nomic.dataset:_create_project:847 - Organization name: `wilsonlin`
2024-12-02 20:40:42.420 | INFO     | nomic.dataset:_create_project:875 - Creating dataset `foo-foo`
(.venv) @wilson-nomic ➜ /workspaces/nomic (normalize-slug) $ python create.py
2024-12-02 20:41:05.278 | INFO     | nomic.dataset:__init__:783 - Loading existing dataset `wilsonlin/foo-foo`.
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Normalize dataset slugs in `AtlasDataset.__init__()` to prevent duplicate dataset creation due to mismatched slug formats.
> 
>   - **Behavior**:
>     - Normalize dataset slugs in `AtlasDataset.__init__()` before sending requests to the server.
>     - Handles accents, spaces, underscores, and non-alphanumeric characters.
>   - **Implementation**:
>     - Uses `unicodedata.normalize` for accent normalization.
>     - Converts to lowercase and replaces spaces/underscores with hyphens.
>     - Removes non-alphanumeric characters except hyphens using regex.
>     - Collapses multiple hyphens into one.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for e3f9c5a27b3720d601266b79bf083f9580c5a72b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->