### PR TITLE
Do not warn about lack of auto-labeled topics when topic model is disabled

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1074,6 +1074,7 @@ class AtlasDataset(AtlasClass):
         else:
             projection = NomicProjectOptions()
 
+        topic_model_was_false = topic_model is False
         if isinstance(topic_model, Dict):
             topic_model = NomicTopicOptions(**topic_model)
         elif isinstance(topic_model, NomicTopicOptions):
@@ -1117,7 +1118,7 @@ class AtlasDataset(AtlasClass):
 
         build_template = {}
         if modality == "embedding":
-            if topic_model.topic_label_field is None:
+            if (not topic_model_was_false) and topic_model.topic_label_field is None:
                 logger.warning(
                     "You did not specify the `topic_label_field` option in your topic_model, your dataset will not contain auto-labeled topics."
                 )


### PR DESCRIPTION
When explicitly passing `topic_model=False`, a warning is shown about "your topic model", which is confusing as the caller explicitly specified not to have one.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent warning in `create_index()` about missing `topic_label_field` when `topic_model` is explicitly set to `False`.
> 
>   - **Behavior**:
>     - In `create_index()` in `nomic/dataset.py`, prevent warning about missing `topic_label_field` when `topic_model` is explicitly set to `False`.
>     - Introduces `topic_model_was_false` flag to track if `topic_model` was initially `False`.
>     - Updates warning condition to check `topic_model_was_false` before logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for 00417c8b6768fd9bdac7f28f357173549a01577b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->