### PR TITLE
feat: show progress bar when embedding using local model

### DIFF
--- a/nomic/embed.py
+++ b/nomic/embed.py
@@ -295,7 +295,7 @@ def _text_embed4all(
         end = min(len(texts), start + batch_size)
         b = end - start
         out = _embed4all.embed(
-            texts,
+            texts[start:end],
             prefix=task_type,
             dimensionality=dimensionality,
             long_text_mode=long_text_mode,


### PR DESCRIPTION
Show a progress bar when using `nomic.embed.text(..., inference_mode="local")`.

Resolves https://linear.app/nomic/issue/NOM-2283/tqdm-progress-bar-for-embedtext-would-be-nice.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a progress bar to `_text_embed4all()` in `nomic/embed.py` for local text embedding, updating with each batch processed.
> 
>   - **Behavior**:
>     - Adds a progress bar using `tqdm` in `_text_embed4all()` in `nomic/embed.py` for local text embedding.
>     - Progress bar updates for each batch of texts processed, providing real-time feedback.
>   - **Misc**:
>     - Resolves issue NOM-2283 regarding the addition of a progress bar for `embed.text()` with `inference_mode="local"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for d438bae2f301e81c570a0d83247fcd45137573b0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->