### PR TITLE
fix: internal schema attr does not exist when loading existing AtlasDataset

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -785,6 +785,8 @@ class AtlasDataset(AtlasClass):
                 f"Passing organization_name has been removed in Nomic Python client 3.0. Instead identify your dataset with `organization_name/project_name` (e.g. sterling-cooper/november-ads)."
             )
 
+        # Set this before possible early return.
+        self._schema = None
         if dataset_id is not None:
             self.meta = self._get_project_by_id(dataset_id)
             return
@@ -817,7 +819,6 @@ class AtlasDataset(AtlasClass):
             )
 
         self.meta = self._get_project_by_id(project_id=dataset_id)
-        self._schema = None
 
     def delete(self):
         """


### PR DESCRIPTION
We should always set `self._schema` to avoid an exception when a user accesses the `schema` field. Right now, there's an early return that prevents the current assignment to the attribute from being reached.

Fixes #364 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `self._schema` to `None` early in `AtlasDataset.__init__()` to prevent exceptions when accessing `schema`.
> 
>   - **Behavior**:
>     - In `AtlasDataset.__init__()`, set `self._schema` to `None` before any early return to prevent exceptions when accessing `schema`.
>   - **Fixes**:
>     - Fixes issue #364 where accessing `schema` could raise an exception if `dataset_id` is provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for b833d5e677bd9304ecc4a253feba02e813c4e818. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->