### PR TITLE
fix: handle identifiers with slash

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -773,10 +773,13 @@ class AtlasDataset(AtlasClass):
         assert identifier is not None or dataset_id is not None, "You must pass a dataset identifier"
         # Normalize identifier.
         if identifier is not None:
-            identifier = unicodedata.normalize("NFD", identifier)  # normalize accents
+            s = identifier.split("/", 1)
+            identifier = unicodedata.normalize("NFD", s[-1])  # normalize accents
             identifier = identifier.lower().replace(" ", "-").replace("_", "-")
             identifier = re.sub(r"[^a-z0-9-]", "", identifier)
             identifier = re.sub(r"-+", "-", identifier)
+            if len(s) == 2:
+                identifier = f"{s[0]}/{identifier}"
 
         super().__init__()
 


### PR DESCRIPTION
Don't normalize organization part of dataset identifier if provided. Fixes regression caused by #361.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes regression in `AtlasDataset.__init__()` to correctly handle dataset identifiers with slashes by preserving the organization part.
> 
>   - **Behavior**:
>     - Fixes regression in `AtlasDataset.__init__()` by correctly handling dataset identifiers with slashes.
>     - Splits identifier on slash and normalizes only the dataset part, preserving the organization part.
>     - Reconstructs identifier with organization part if present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for ba7f6dba2f5cd3d8ab05a67c19efd1fcaa0c6853. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->