### PR TITLE
fix: added missing docstring description for indexed_field in map_data

### DIFF
--- a/nomic/atlas.py
+++ b/nomic/atlas.py
@@ -44,6 +44,7 @@ def map_data(
         description: The description of your dataset
         id_field: Specify your data unique id field. This field can be up 36 characters in length. If not specified, one will be created for you named `id_`.
         is_public: Should the dataset be accessible outside your Nomic Atlas organization.
+        indexed_field: The text field from the dataset that will be used to create embeddings, which determines the layout of the data map in Atlas. Required for text data but won't have an impact if uploading embeddings or image blobs.
         projection: Options to adjust Nomic Project - the dimensionality algorithm organizing your dataset.
         topic_model: Options to adjust Nomic Topic - the topic model organizing your dataset.
         duplicate_detection: Options to adjust Nomic Duplicates - the duplicate detection algorithm.


### PR DESCRIPTION
This PR adds indexed_field and a description to the Args for map_data

Current docstring for map_data skips `indexed_field` for some reason:

```
Args:
        data: An ordered collection of the datapoints you are structuring. Can be a list of dictionaries, Pandas Dataframe or PyArrow Table.
        blobs: A list of image paths, bytes, or PIL images to add to your image dataset that are stored locally.
        embeddings: An [N,d] numpy array containing the N embeddings to add.
        identifier: A name for your dataset that is used to generate the dataset identifier. A unique name will be chosen if not supplied.
        description: The description of your dataset
        id_field: Specify your data unique id field. This field can be up 36 characters in length. If not specified, one will be created for you named `id_`.
        is_public: Should the dataset be accessible outside your Nomic Atlas organization.
        projection: Options to adjust Nomic Project - the dimensionality algorithm organizing your dataset.
        topic_model: Options to adjust Nomic Topic - the topic model organizing your dataset.
        duplicate_detection: Options to adjust Nomic Duplicates - the duplicate detection algorithm.
        embedding_model: Options to adjust the embedding model used to embed your dataset.
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds missing docstring for `indexed_field` parameter in `map_data()` in `nomic/atlas.py`.
> 
>   - **Documentation**:
>     - Adds missing docstring for `indexed_field` parameter in `map_data()` in `nomic/atlas.py`. Describes its role in creating embeddings and its impact on data layout in Atlas.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for 701724d2ac991503d171721b6a6b06b6166510e5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->