### PR TITLE
fix: adding deprecations to docstrings

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1376,9 +1376,7 @@ class AtlasDataset(AtlasClass):
 
         """
 
-        raise DeprecationWarning(
-            f"The function AtlasDataset.delete_data is deprecated."
-        )
+        raise DeprecationWarning(f"The function AtlasDataset.delete_data is deprecated.")
 
     def add_data(
         self,

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1373,7 +1373,6 @@ class AtlasDataset(AtlasClass):
 
         Returns:
             True if data deleted successfully.
-
         """
 
         raise DeprecationWarning(f"The function AtlasDataset.delete_data is deprecated.")

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1367,6 +1367,7 @@ class AtlasDataset(AtlasClass):
         """
         Deletes the specified datapoints from the dataset.
 
+        .. deprecated:: 3.4.0
         Args:
             ids: A list of data ids to delete
 
@@ -1374,19 +1375,10 @@ class AtlasDataset(AtlasClass):
             True if data deleted successfully.
 
         """
-        if not isinstance(ids, list):
-            raise ValueError("You must specify a list of ids when deleting datums.")
 
-        response = requests.post(
-            self.atlas_api_path + "/v1/project/data/delete",
-            headers=self.header,
-            json={"project_id": self.id, "datum_ids": ids},
+        raise DeprecationWarning(
+            f"The function AtlasDataset.delete_data is deprecated."
         )
-
-        if response.status_code == 200:
-            return True
-        else:
-            raise Exception(response.text)
 
     def add_data(
         self,
@@ -1728,11 +1720,12 @@ class AtlasDataset(AtlasClass):
         """
         Utility method to update a project's maps by adding the given data.
 
-        Args:
-            data: An [N,] element list of dictionaries containing metadata for each embedding.
-            embeddings: An [N, d] matrix of embeddings for updating embedding dataset. Leave as None to update text dataset.
-            shard_size: Data is uploaded in parallel by many threads. Adjust the number of datums to upload by each worker.
-            num_workers: The number of workers to use when sending data.
+        .. deprecated:: 3.4.0
+            Args:
+                data: An [N,] element list of dictionaries containing metadata for each embedding.
+                embeddings: An [N, d] matrix of embeddings for updating embedding dataset. Leave as None to update text dataset.
+                shard_size: Data is uploaded in parallel by many threads. Adjust the number of datums to upload by each worker.
+                num_workers: The number of workers to use when sending data.
 
         """
 
@@ -1745,8 +1738,9 @@ class AtlasDataset(AtlasClass):
         Rebuilds all maps in a dataset with the latest state dataset data state. Maps will not be rebuilt to
         reflect the additions, deletions or updates you have made to your data until this method is called.
 
-        Args:
-            rebuild_topic_models: (Default False) - If true, will create new topic models when updating these indices.
+        .. deprecated:: 3.4.0
+            Args:
+                rebuild_topic_models: (Default False) - If true, will create new topic models when updating these indices.
         """
 
         raise DeprecationWarning(

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1717,7 +1717,7 @@ class AtlasDataset(AtlasClass):
         """
         Utility method to update a project's maps by adding the given data.
 
-        .. deprecated:: 3.4.0
+        .. deprecated:: 3.3.1
             Args:
                 data: An [N,] element list of dictionaries containing metadata for each embedding.
                 embeddings: An [N, d] matrix of embeddings for updating embedding dataset. Leave as None to update text dataset.
@@ -1735,7 +1735,7 @@ class AtlasDataset(AtlasClass):
         Rebuilds all maps in a dataset with the latest state dataset data state. Maps will not be rebuilt to
         reflect the additions, deletions or updates you have made to your data until this method is called.
 
-        .. deprecated:: 3.4.0
+        .. deprecated:: 3.3.1
             Args:
                 rebuild_topic_models: (Default False) - If true, will create new topic models when updating these indices.
         """


### PR DESCRIPTION
Adding deprecations to docstrings which will allow our python SDK -> autogenerated docs pipeline to ignore deprecated functions when running `generateMarkdownFromPython.py` in the docs repo using pydoc_markdown FilterProcessor 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add deprecation notices to `delete_data()`, `update_maps()`, and `update_indices()` in `AtlasDataset` to support documentation filtering.
> 
>   - **Deprecations**:
>     - Add `.. deprecated:: 3.4.0` to `delete_data()` in `AtlasDataset`.
>     - Add `.. deprecated:: 3.3.1` to `update_maps()` and `update_indices()` in `AtlasDataset`.
>   - **Exceptions**:
>     - `delete_data()`, `update_maps()`, and `update_indices()` now raise `DeprecationWarning`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for 2da047d5554bf2372f70d3ee82a7bd331d0c686c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->