### PR TITLE
fix: fix spelling

### DIFF
--- a/nomic/utils.py
+++ b/nomic/utils.py
@@ -104,7 +104,7 @@ nouns = [
     "fisher",
     "jaynes",
     "bernoulli",
-    "alembert",
+    "diderot",
     "gibbs",
     "pareto",
     "levy",


### PR DESCRIPTION
'alembert' is an autogenerated name, and it reads weirdly to not have it be `d'alembert`. So let's replace him with his partner in crime*.

*where 'crime' is against canon law.