### PR TITLE
fix: ValueError returned when calling map_data on blobs and embeddings

### DIFF
--- a/nomic/atlas.py
+++ b/nomic/atlas.py
@@ -64,7 +64,9 @@ def map_data(
 
     if blobs is not None:
         if embeddings is not None:
-            raise ValueError("You cannot pass both `blobs` and `embeddings` to map_data(). To create a map of images, include `blobs` and not `embeddings`. To create a map of embeddings with images as metadata, include your images as a field in your `data`.")
+            raise ValueError(
+                "You cannot pass both `blobs` and `embeddings` to map_data(). To create a map of images, include `blobs` and not `embeddings`. To create a map of embeddings with images as metadata, include your images as a field in your `data`."
+            )
         # change this when we support other modalities
         modality = "image"
         indexed_field = "_blob_hash"

--- a/nomic/atlas.py
+++ b/nomic/atlas.py
@@ -65,7 +65,7 @@ def map_data(
     if blobs is not None:
         if embeddings is not None:
             raise ValueError(
-                "You cannot pass both `blobs` and `embeddings` to map_data(). To create a map of images, include `blobs` and not `embeddings`. To create a map of embeddings with images as metadata, include your images as a field in your `data`."
+                "You cannot pass both `blobs` and `embeddings` to map_data(). To create a map of images, include `blobs` and not `embeddings`. To create a map of embeddings with images as metadata, include your images as a field in your `data` parameter."
             )
         # change this when we support other modalities
         modality = "image"

--- a/nomic/atlas.py
+++ b/nomic/atlas.py
@@ -63,6 +63,8 @@ def map_data(
         modality = "text"
 
     if blobs is not None:
+        if embeddings is not None:
+            raise ValueError("You cannot pass both `blobs` and `embeddings` to map_data(). To create a map of images, include `blobs` and not `embeddings`. To create a map of embeddings with images as metadata, include your images as a field in your `data`.")
         # change this when we support other modalities
         modality = "image"
         indexed_field = "_blob_hash"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a check in `map_data()` to raise `ValueError` if both `blobs` and `embeddings` are provided, ensuring correct usage of parameters.
> 
>   - **Behavior**:
>     - In `map_data()` in `atlas.py`, added a check to raise `ValueError` if both `blobs` and `embeddings` are provided, clarifying that only one can be used at a time.
>   - **Error Handling**:
>     - Provides a specific error message guiding users on how to correctly use `blobs` and `embeddings` parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for befec4f597f37d359f9814db0e8f44b0c0452253. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->