### PR TITLE
[draft] remove requirement for AtlasDataset unique-id-field

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -805,8 +805,6 @@ class AtlasDataset(AtlasClass):
             dataset_id = dataset["id"]
 
         if dataset_id is None:  # if there is no existing project, make a new one.
-            if unique_id_field is None:  # if not all parameters are specified, we weren't trying to make a project
-                raise ValueError(f"Dataset `{identifier}` does not exist.")
 
             # if modality is None:
             #     raise ValueError("You must specify a modality when creating a new dataset.")
@@ -840,7 +838,7 @@ class AtlasDataset(AtlasClass):
         self,
         identifier: str,
         description: Optional[str],
-        unique_id_field: str,
+        unique_id_field: Optional[str],
         is_public: bool = True,
     ):
         """
@@ -872,8 +870,6 @@ class AtlasDataset(AtlasClass):
         #     )
         #     raise ValueError(msg)
 
-        if unique_id_field is None:
-            raise ValueError("You must specify a unique id field")
         if description is None:
             description = ""
         response = requests.post(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove requirement for `unique_id_field` in `AtlasDataset` creation, allowing it to be optional.
> 
>   - **Behavior**:
>     - Removed requirement for `unique_id_field` in `AtlasDataset.__init__()` and `AtlasDataset._create_project()`.
>     - Deleted exceptions raised when `unique_id_field` is `None` in both methods.
>   - **Parameters**:
>     - Changed `unique_id_field` parameter to `Optional[str]` in `AtlasDataset._create_project()`.
>   - **Misc**:
>     - Removed unused code related to `unique_id_field` checks in `dataset.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for 1f7da156cdf3d2285d073667642c946bdf9392f7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->