### PR TITLE
chore: remove get_atoms from AtlasProjection

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -700,33 +700,6 @@ class AtlasProjection:
     def datum_id_field(self):
         return self.dataset.meta["unique_id_field"]
 
-    def _get_atoms(self, ids: List[str]) -> List[Dict]:
-        """
-        Retrieves atoms by id
-
-        Args:
-            ids: list of atom ids
-
-        Returns:
-            A dictionary containing the resulting atoms, keyed by atom id.
-
-        """
-
-        if not isinstance(ids, list):
-            raise ValueError("You must specify a list of ids when getting data.")
-
-        response = requests.post(
-            self.dataset.atlas_api_path + "/v1/project/atoms/get",
-            headers=self.dataset.header,
-            json={"project_id": self.dataset.id, "index_id": self.atlas_index_id, "atom_ids": ids},
-        )
-
-        if response.status_code == 200:
-            return response.json()["atoms"]
-        else:
-            raise Exception(response.text)
-
-
 class AtlasDataStream(AtlasClass):
     def __init__(self, name: Optional[str] = "contrastors"):
         super().__init__()

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -700,6 +700,7 @@ class AtlasProjection:
     def datum_id_field(self):
         return self.dataset.meta["unique_id_field"]
 
+
 class AtlasDataStream(AtlasClass):
     def __init__(self, name: Optional[str] = "contrastors"):
         super().__init__()

--- a/tests/test_atlas_client.py
+++ b/tests/test_atlas_client.py
@@ -50,7 +50,7 @@ def wait_for_projection_ready(dataset, timeout_minutes=10):
                 break
         time.sleep(5)
         num_tries += 1
-        if num_tries > timeout_minutes * 12:  # 12 tries per minute (5 second intervals)
+        if num_tries > timeout_minutes * 12:
             raise TimeoutError(f"Timed out waiting for projection to be ready after {timeout_minutes} minutes")
 
 

--- a/tests/test_atlas_client.py
+++ b/tests/test_atlas_client.py
@@ -28,7 +28,7 @@ def gen_temp_identifier() -> str:
     return f'{now}-{rand}'
 
 
-def wait_for_projection_ready(dataset, timeout_minutes=5):
+def wait_for_projection_ready(dataset, timeout_minutes=10):
     """Helper function to wait for a projection to be ready.
     
     Args:

--- a/tests/test_atlas_client.py
+++ b/tests/test_atlas_client.py
@@ -174,7 +174,7 @@ def test_topics():
     )
 
     map = dataset.maps[0]
-    wait_for_projection_ready(dataset, map.projection_id)
+    wait_for_projection_ready(dataset)
 
     assert len(map.topics.metadata) > 0
 
@@ -214,7 +214,7 @@ def test_data():
     )
 
     map = dataset.maps[0]
-    wait_for_projection_ready(dataset, map.projection_id)
+    wait_for_projection_ready(dataset)
 
     df = map.data.df
     assert len(df) > 0
@@ -339,7 +339,7 @@ def test_map_embeddings():
     )
 
     map = dataset.maps[0]
-    wait_for_projection_ready(dataset, map.projection_id)
+    wait_for_projection_ready(dataset)
 
     retrieved_embeddings = map.embeddings.latent
 
@@ -351,7 +351,7 @@ def test_map_embeddings():
 
     dataset.create_index()
     map = dataset.maps[0]  # Get the new map after create_index
-    wait_for_projection_ready(dataset, map.projection_id)
+    wait_for_projection_ready(dataset)
 
     neighbors, _ = map.embeddings.vector_search(queries=np.random.rand(1, 10), k=2)
     assert len(neighbors[0]) == 2


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `_get_atoms` from `AtlasProjection` and update tests to use `wait_for_projection_ready` in `tests/test_atlas_client.py`.
> 
>   - **Removal**:
>     - Remove `_get_atoms` method from `AtlasProjection` in `nomic/dataset.py`.
>   - **Testing**:
>     - Add `wait_for_projection_ready` helper function in `tests/test_atlas_client.py` to wait for projection readiness.
>     - Replace `wait_for_dataset_lock` with `wait_for_projection_ready` in `test_topics`, `test_data`, and `test_map_embeddings` in `tests/test_atlas_client.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for 302a8fe11e951dcfb18fc5d3e90510f5b5a3104d. You can [customize](https://app.ellipsis.dev/nomic-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->