### PR TITLE
fix: unique id optional

### DIFF
--- a/nomic/atlas.py
+++ b/nomic/atlas.py
@@ -3,7 +3,6 @@ This class allows for programmatic interactions with Atlas - Nomic's neural data
 or in a Jupyter Notebook to organize and interact with your unstructured data.
 """
 
-import uuid
 from typing import Dict, Iterable, List, Optional, Union
 
 import numpy as np
@@ -42,7 +41,7 @@ def map_data(
         embeddings: An [N,d] numpy array containing the N embeddings to add.
         identifier: A name for your dataset that is used to generate the dataset identifier. A unique name will be chosen if not supplied.
         description: The description of your dataset
-        id_field: Specify your data unique id field. This field can be up 36 characters in length. If not specified, one will be created for you named `id_`.
+        id_field: Specify a field that uniquely identifies each datapoint. This field can be up 36 characters in length.
         is_public: Should the dataset be accessible outside your Nomic Atlas organization.
         indexed_field: The text field from the dataset that will be used to create embeddings, which determines the layout of the data map in Atlas. Required for text data but won't have an impact if uploading embeddings or image blobs.
         projection: Options for configuring the 2D projection algorithm.
@@ -86,9 +85,6 @@ def map_data(
             # default to vision v1.5
             embedding_model = NomicEmbedOptions(model="nomic-embed-vision-v1.5")
 
-    if id_field is None:
-        id_field = ATLAS_DEFAULT_ID_FIELD
-
     project_name = get_random_name()
 
     dataset_name = project_name
@@ -99,38 +95,6 @@ def map_data(
         index_name = identifier
     if description:
         description = description
-
-    # no metadata was specified
-    added_id_field = False
-
-    if data is None:
-        added_id_field = True
-        if embeddings is not None:
-            data = [{ATLAS_DEFAULT_ID_FIELD: b64int(i)} for i in range(len(embeddings))]
-        elif blobs is not None:
-            data = [{ATLAS_DEFAULT_ID_FIELD: b64int(i)} for i in range(len(blobs))]
-        else:
-            raise ValueError("You must specify either data, embeddings, or blobs")
-
-    if id_field == ATLAS_DEFAULT_ID_FIELD and data is not None:
-        if isinstance(data, list) and id_field not in data[0]:
-            added_id_field = True
-            for i in range(len(data)):
-                # do not modify object the user passed in - also ensures IDs are unique if two input datums are the same *object*
-                data[i] = data[i].copy()
-                data[i][id_field] = b64int(i)
-        elif isinstance(data, DataFrame) and id_field not in data.columns:
-            data[id_field] = [b64int(i) for i in range(data.shape[0])]
-            added_id_field = True
-        elif isinstance(data, pa.Table) and not id_field in data.column_names:  # type: ignore
-            ids = pa.array([b64int(i) for i in range(len(data))])
-            data = data.append_column(id_field, ids)  # type: ignore
-            added_id_field = True
-        elif id_field not in data[0]:
-            raise ValueError("map_data data must be a list of dicts, a pandas dataframe, or a pyarrow table")
-
-    if added_id_field:
-        logger.warning("An ID field was not specified in your data so one was generated for you in insertion order.")
 
     dataset = AtlasDataset(
         identifier=dataset_name, description=description, unique_id_field=id_field, is_public=is_public
@@ -202,7 +166,7 @@ def map_embeddings(
     Args:
         embeddings: An [N,d] numpy array containing the batch of N embeddings to add.
         data: An [N,] element list of dictionaries containing metadata for each embedding.
-        id_field: Specify your data unique id field. This field can be up 36 characters in length. If not specified, one will be created for you named `id_`.
+        id_field: Specify a field that uniquely identifies each datapoint. This field can be up 36 characters in length.
         name: A name for your dataset. Specify in the format `organization/project` to create in a specific organization.
         description: A description for your map.
         is_public: Should this embedding map be public? Private maps can only be accessed by members of your organization.
@@ -250,7 +214,7 @@ def map_text(
     Args:
         data: An [N,] element iterable of dictionaries containing metadata for each embedding.
         indexed_field: The name the data field containing the text your want to map.
-        id_field: Specify your data unique id field. This field can be up 36 characters in length. If not specified, one will be created for you named `id_`.
+        id_field: Specify a field that uniquely identifies each datapoint. This field can be up 36 characters in length.
         name: A name for your dataset. Specify in the format `organization/project` to create in a specific organization.
         description: A description for your map.
         build_topic_model: Builds a hierarchical topic model over your data to discover patterns.

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -308,7 +308,7 @@ class AtlasClass(object):
 
             # Check ID field length (36 characters max)
             if pa.types.is_string(data[id_field].type):
-                max_length = pa.compute.max(pa.compute.utf8_length(data[id_field])).as_py()
+                max_length = pc.max(pc.utf8_length(data[id_field])).as_py()
                 if max_length > 36:
                     raise ValueError(
                         f"The id_field contains values greater than 36 characters. Atlas does not support id_fields longer than 36 characters."
@@ -346,10 +346,10 @@ class AtlasClass(object):
                         f"Replacing {data[field.name].null_count} null values for field {field.name} with string 'null'. This behavior will change in a future version."
                     )
                     reformatted[field.name] = pc.fill_null(reformatted[field.name], "null")
-                if pa.compute.any(pa.compute.equal(pa.compute.binary_length(reformatted[field.name]), 0)):  # type: ignore
-                    mask = pa.compute.equal(pa.compute.binary_length(reformatted[field.name]), 0).combine_chunks()  # type: ignore
+                if pc.any(pc.equal(pc.binary_length(reformatted[field.name]), 0)):  # type: ignore
+                    mask = pc.equal(pc.binary_length(reformatted[field.name]), 0).combine_chunks()  # type: ignore
                     assert pa.types.is_boolean(mask.type)  # type: ignore
-                    reformatted[field.name] = pa.compute.replace_with_mask(reformatted[field.name], mask, "null")  # type: ignore
+                    reformatted[field.name] = pc.replace_with_mask(reformatted[field.name], mask, "null")  # type: ignore
         for field in data.schema:
             if not field.name in reformatted:
                 if field.name == "_embeddings":

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -349,7 +349,7 @@ class AtlasClass(object):
                         f"Replacing {data[field.name].null_count} null values for field {field.name} with string 'null'. This behavior will change in a future version."
                     )
                     reformatted[field.name] = pc.fill_null(reformatted[field.name], "null")
-                
+
                 # Check for empty strings and replace with "null"
                 # Separate the operations for better type checking
                 binary_length_values = pc.binary_length(reformatted[field.name])  # type: ignore

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1385,7 +1385,9 @@ class AtlasDataset(AtlasClass):
             temp_id_values = [str(uuid.uuid4()) for _ in range(data_length)]
             # Check if original data already has the id_field, if not, it's an issue for later _add_data
             if self.id_field not in data_as_table.column_names and TEMP_ID_COLUMN != self.id_field:
-                 logger.warning(f"Input data for _add_blobs does not contain the designated id_field '{self.id_field}'. Temporary IDs will be used for blob association, but ensure '{self.id_field}' is present for the final data addition.")
+                logger.warning(
+                    f"Input data for _add_blobs does not contain the designated id_field '{self.id_field}'. Temporary IDs will be used for blob association, but ensure '{self.id_field}' is present for the final data addition."
+                )
 
             data_as_table = data_as_table.append_column(TEMP_ID_COLUMN, pa.array(temp_id_values, type=pa.string()))
         except Exception as e:
@@ -1478,7 +1480,7 @@ class AtlasDataset(AtlasClass):
             upload_pbar.close()
 
         hash_schema = pa.schema([(TEMP_ID_COLUMN, pa.string()), ("_blob_hash", pa.string())])
-        
+
         merged_data_as_table: pa.Table
         if succeeded_uploads > 0:  # Only create hash_tb if there are successful uploads
             hash_tb = pa.Table.from_pydict(
@@ -1487,10 +1489,11 @@ class AtlasDataset(AtlasClass):
             merged_data_as_table = data_as_table.join(right_table=hash_tb, keys=TEMP_ID_COLUMN, join_type="left outer")
         else:  # No successful uploads, so no hashes to merge, but keep original data structure
             # Need to ensure _blob_hash column is added with nulls, and id_field is present
-            if '_blob_hash' not in data_as_table.column_names:
-                data_as_table = data_as_table.append_column("_blob_hash", pa.nulls(data_as_table.num_rows, type=pa.string()))
+            if "_blob_hash" not in data_as_table.column_names:
+                data_as_table = data_as_table.append_column(
+                    "_blob_hash", pa.nulls(data_as_table.num_rows, type=pa.string())
+                )
             merged_data_as_table = data_as_table
-
 
         merged_data_as_table = merged_data_as_table.drop_columns([TEMP_ID_COLUMN])
 

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1465,7 +1465,7 @@ class AtlasDataset(AtlasClass):
             upload_pbar.close()
 
         hash_schema = pa.schema([(TEMP_ID_COLUMN, pa.string()), ("_blob_hash", pa.string())])
-        
+
         merged_data_as_table: pa.Table
         if succeeded_uploads > 0:  # Only create hash_tb if there are successful uploads
             hash_tb = pa.Table.from_pydict(
@@ -1473,8 +1473,9 @@ class AtlasDataset(AtlasClass):
             )
             merged_data_as_table = data_as_table.join(right_table=hash_tb, keys=TEMP_ID_COLUMN, join_type="left outer")
         else:  # No successful uploads, so no hashes to merge, but keep original data structure
-            merged_data_as_table = data_as_table.add_column(data_as_table.num_rows, "_blob_hash", pa.nulls(data_as_table.num_rows, type=pa.string()))
-
+            merged_data_as_table = data_as_table.add_column(
+                data_as_table.num_rows, "_blob_hash", pa.nulls(data_as_table.num_rows, type=pa.string())
+            )
 
         merged_data_as_table = merged_data_as_table.drop_columns([TEMP_ID_COLUMN])
 

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1465,7 +1465,7 @@ class AtlasDataset(AtlasClass):
             upload_pbar.close()
 
         hash_schema = pa.schema([(TEMP_ID_COLUMN, pa.string()), ("_blob_hash", pa.string())])
-
+        
         merged_data_as_table: pa.Table
         if succeeded_uploads > 0:  # Only create hash_tb if there are successful uploads
             hash_tb = pa.Table.from_pydict(
@@ -1473,9 +1473,8 @@ class AtlasDataset(AtlasClass):
             )
             merged_data_as_table = data_as_table.join(right_table=hash_tb, keys=TEMP_ID_COLUMN, join_type="left outer")
         else:  # No successful uploads, so no hashes to merge, but keep original data structure
-            merged_data_as_table = data_as_table.add_column(
-                data_as_table.num_rows, "_blob_hash", pa.nulls(data_as_table.num_rows, type=pa.string())
-            )
+            merged_data_as_table = data_as_table.add_column(data_as_table.num_rows, "_blob_hash", pa.nulls(data_as_table.num_rows, type=pa.string()))
+
 
         merged_data_as_table = merged_data_as_table.drop_columns([TEMP_ID_COLUMN])
 

--- a/tests/test_atlas_client.py
+++ b/tests/test_atlas_client.py
@@ -68,7 +68,7 @@ def test_integration_map_embeddings_with_errors():
             embeddings=embeddings,
             data=data,
             identifier=name,
-                is_public=True,
+            is_public=True,
         )
 
         assert isinstance(dataset.created_timestamp, datetime)
@@ -119,7 +119,7 @@ def test_date_metadata():
         dataset = atlas.map_data(
             embeddings=embeddings,
             identifier=f"unittest-dataset-{gen_temp_identifier()}",
-                data=data,
+            data=data,
             is_public=True,
         )
         dataset.delete()
@@ -130,10 +130,7 @@ def test_topics():
     embeddings = np.random.rand(num_embeddings, 10)
     texts = ["foo", "bar", "baz", "bat"]
     dates = [datetime(2021, 1, 1), datetime(2022, 1, 1), datetime(2023, 1, 1)]
-    data = [
-        {"upload": 0.0, "text": texts[i % 4], "date": dates[i % 3]}
-        for i in range(len(embeddings))
-    ]
+    data = [{"upload": 0.0, "text": texts[i % 4], "date": dates[i % 3]} for i in range(len(embeddings))]
 
     dataset = atlas.map_data(
         embeddings=embeddings,
@@ -156,10 +153,7 @@ def test_data():
     num_embeddings = 100
     embeddings = np.random.rand(num_embeddings, 10)
     texts = ["foo", "bar", "baz", "bat"]
-    data = [
-        {"upload": 0.0, "text": str(i)}
-        for i in range(len(embeddings))
-    ]
+    data = [{"upload": 0.0, "text": str(i)} for i in range(len(embeddings))]
     all_columns = data[0].keys()
 
     dataset = atlas.map_data(
@@ -747,7 +741,7 @@ def test_integration_map_images():
     # Generate random PIL images
     images = []
     for _ in range(size):
-        img = Image.new('RGB', (60, 30), color = (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255)))
+        img = Image.new("RGB", (60, 30), color=(random.randint(0, 255), random.randint(0, 255), random.randint(0, 255)))
         images.append(img)
 
     data = pd.DataFrame(
@@ -763,7 +757,7 @@ def test_integration_map_images():
         is_public=True,
     )
     assert dataset.id is not None
-    assert dataset.modality == "image" # Or check based on how map_data sets it.
+    assert dataset.modality == "image"  # Or check based on how map_data sets it.
 
     projection = dataset.maps[0]
     _wait_for_projection_completion(projection)
@@ -774,6 +768,6 @@ def test_integration_map_images():
     # Check if topics can be accessed (even if empty, should not error)
     # Depending on default topic modeling for images, this might need adjustment
     # For now, let's assume topics might be generated or accessible without error.
-    assert isinstance(projection.topics.metadata, list) # or dict, check actual type
+    assert isinstance(projection.topics.metadata, list)  # or dict, check actual type
 
     dataset.delete()

--- a/tests/test_atlas_client.py
+++ b/tests/test_atlas_client.py
@@ -30,8 +30,9 @@ def gen_temp_identifier() -> str:
 def test_integration_map_idless_embeddings():
     num_embeddings = 50
     embeddings = np.random.rand(num_embeddings, 512)
+    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
 
-    dataset = atlas.map_data(identifier=f"unittest-dataset-{gen_temp_identifier()}", embeddings=embeddings)
+    dataset = atlas.map_data(identifier=f"unittest-dataset-{gen_temp_identifier()}", embeddings=embeddings, data=data_payload)
     AtlasDataset(dataset.identifier).delete()
 
 
@@ -291,10 +292,12 @@ def test_weird_inputs():
 def test_integration_map_embeddings():
     num_embeddings = 20
     embeddings = np.random.rand(num_embeddings, 10)
+    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
 
     dataset = atlas.map_data(
         embeddings=embeddings,
         identifier=f"unittest-dataset-{gen_temp_identifier()}",
+        data=data_payload,
         is_public=True,
     )
 
@@ -407,11 +410,13 @@ def _wait_for_projection_completion(projection, timeout_seconds=600):
 def test_integration_map_embeddings_explicit_umap():
     num_embeddings = 50
     embeddings = np.random.rand(num_embeddings, 10)
+    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
 
     dataset_identifier = f"unittest-umap-explicit-{gen_temp_identifier()}"
     dataset = atlas.map_data(
         identifier=dataset_identifier,
         embeddings=embeddings,
+        data=data_payload,
         is_public=True,
         projection=ProjectionOptions(model="umap", n_neighbors=5, min_dist=0.01, n_epochs=25),
     )
@@ -439,11 +444,13 @@ def test_map_embeddings_explicit_umap(mock_map_data, mock_wait_for_completion):
     embeddings = np.random.rand(num_embeddings, 10)
     dataset_identifier = f"unittest-umap-explicit-{gen_temp_identifier()}"
     umap_options = ProjectionOptions(model="umap", n_neighbors=5, min_dist=0.01, n_epochs=25)
+    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
 
     # Call the function that would normally call atlas.map_data
     dataset_out = atlas.map_data(
         identifier=dataset_identifier,
         embeddings=embeddings,
+        data=data_payload,
         is_public=True,
         projection=umap_options,
     )
@@ -453,6 +460,7 @@ def test_map_embeddings_explicit_umap(mock_map_data, mock_wait_for_completion):
 
     assert called_kwargs["identifier"] == dataset_identifier
     assert np.array_equal(called_kwargs["embeddings"], embeddings)
+    assert called_kwargs["data"] == data_payload
     assert called_kwargs["is_public"] is True
     actual_projection_options = called_kwargs["projection"]
     assert isinstance(actual_projection_options, ProjectionOptions)
@@ -551,11 +559,13 @@ def test_map_text_explicit_umap(mock_map_data, mock_wait_for_completion):
 def test_integration_map_embeddings_explicit_nomic_project():
     num_embeddings = 50
     embeddings = np.random.rand(num_embeddings, 10)
+    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
 
     dataset_identifier = f"unittest-nomic-explicit-{gen_temp_identifier()}"
     dataset = atlas.map_data(
         identifier=dataset_identifier,
         embeddings=embeddings,
+        data=data_payload,
         is_public=True,
         projection=ProjectionOptions(model="nomic-project-v1", n_neighbors=7, n_epochs=20, spread=0.6),
     )
@@ -578,10 +588,12 @@ def test_map_embeddings_explicit_nomic_project(mock_map_data, mock_wait_for_comp
     embeddings = np.random.rand(num_embeddings, 10)
     dataset_identifier = f"unittest-nomic-explicit-{gen_temp_identifier()}"
     nomic_options = ProjectionOptions(model="nomic-project-v1", n_neighbors=7, n_epochs=20, spread=0.6)
+    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
 
     dataset_out = atlas.map_data(
         identifier=dataset_identifier,
         embeddings=embeddings,
+        data=data_payload,
         is_public=True,
         projection=nomic_options,
     )
@@ -589,6 +601,7 @@ def test_map_embeddings_explicit_nomic_project(mock_map_data, mock_wait_for_comp
     called_args, called_kwargs = mock_map_data.call_args
     assert called_kwargs["identifier"] == dataset_identifier
     assert np.array_equal(called_kwargs["embeddings"], embeddings)
+    assert called_kwargs["data"] == data_payload
     assert called_kwargs["is_public"] is True
 
     actual_projection_options = called_kwargs["projection"]
@@ -686,11 +699,13 @@ def test_map_text_explicit_nomic_project(mock_map_data, mock_wait_for_completion
 def test_integration_map_embeddings_auto_with_options():
     num_embeddings = 50  # Small dataset, backend should pick UMAP if it has logic for it
     embeddings = np.random.rand(num_embeddings, 10)
+    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
 
     dataset_identifier = f"unittest-auto-opts-{gen_temp_identifier()}"
     dataset = atlas.map_data(
         identifier=dataset_identifier,
         embeddings=embeddings,
+        data=data_payload,
         is_public=True,
         projection={
             "model": "nomic-project-v1",
@@ -709,12 +724,14 @@ def test_integration_map_embeddings_auto_with_options():
 def test_integration_map_embeddings_legacy_dict_with_explicit_algorithm():
     num_embeddings = 50
     embeddings = np.random.rand(num_embeddings, 10)
+    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
 
     # Test with explicit algorithm="umap"
     dataset_identifier = f"unittest-legacy-dict-algo-umap-{gen_temp_identifier()}"
     dataset = atlas.map_data(
         identifier=dataset_identifier,
         embeddings=embeddings,
+        data=data_payload,
         is_public=True,
         projection={"model": "umap", "n_neighbors": 9, "min_dist": 0.3, "n_epochs": 27},
     )
@@ -727,6 +744,7 @@ def test_integration_map_embeddings_legacy_dict_with_explicit_algorithm():
     dataset = atlas.map_data(
         identifier=dataset_identifier,
         embeddings=embeddings,
+        data=data_payload,
         is_public=True,
         projection={"model": "nomic-project-v2", "n_neighbors": 11, "n_epochs": 28},
     )

--- a/tests/test_atlas_client.py
+++ b/tests/test_atlas_client.py
@@ -30,9 +30,11 @@ def gen_temp_identifier() -> str:
 def test_integration_map_idless_embeddings():
     num_embeddings = 50
     embeddings = np.random.rand(num_embeddings, 512)
-    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
+    data_payload = [{"description": "test_value"} for _ in range(num_embeddings)]
 
-    dataset = atlas.map_data(identifier=f"unittest-dataset-{gen_temp_identifier()}", embeddings=embeddings, data=data_payload)
+    dataset = atlas.map_data(
+        identifier=f"unittest-dataset-{gen_temp_identifier()}", embeddings=embeddings, data=data_payload
+    )
     AtlasDataset(dataset.identifier).delete()
 
 
@@ -292,7 +294,7 @@ def test_weird_inputs():
 def test_integration_map_embeddings():
     num_embeddings = 20
     embeddings = np.random.rand(num_embeddings, 10)
-    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
+    data_payload = [{"description": "test_value"} for _ in range(num_embeddings)]
 
     dataset = atlas.map_data(
         embeddings=embeddings,
@@ -410,7 +412,7 @@ def _wait_for_projection_completion(projection, timeout_seconds=600):
 def test_integration_map_embeddings_explicit_umap():
     num_embeddings = 50
     embeddings = np.random.rand(num_embeddings, 10)
-    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
+    data_payload = [{"description": "test_value"} for _ in range(num_embeddings)]
 
     dataset_identifier = f"unittest-umap-explicit-{gen_temp_identifier()}"
     dataset = atlas.map_data(
@@ -444,7 +446,7 @@ def test_map_embeddings_explicit_umap(mock_map_data, mock_wait_for_completion):
     embeddings = np.random.rand(num_embeddings, 10)
     dataset_identifier = f"unittest-umap-explicit-{gen_temp_identifier()}"
     umap_options = ProjectionOptions(model="umap", n_neighbors=5, min_dist=0.01, n_epochs=25)
-    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
+    data_payload = [{"description": "test_value"} for _ in range(num_embeddings)]
 
     # Call the function that would normally call atlas.map_data
     dataset_out = atlas.map_data(
@@ -559,7 +561,7 @@ def test_map_text_explicit_umap(mock_map_data, mock_wait_for_completion):
 def test_integration_map_embeddings_explicit_nomic_project():
     num_embeddings = 50
     embeddings = np.random.rand(num_embeddings, 10)
-    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
+    data_payload = [{"description": "test_value"} for _ in range(num_embeddings)]
 
     dataset_identifier = f"unittest-nomic-explicit-{gen_temp_identifier()}"
     dataset = atlas.map_data(
@@ -588,7 +590,7 @@ def test_map_embeddings_explicit_nomic_project(mock_map_data, mock_wait_for_comp
     embeddings = np.random.rand(num_embeddings, 10)
     dataset_identifier = f"unittest-nomic-explicit-{gen_temp_identifier()}"
     nomic_options = ProjectionOptions(model="nomic-project-v1", n_neighbors=7, n_epochs=20, spread=0.6)
-    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
+    data_payload = [{"description": "test_value"} for _ in range(num_embeddings)]
 
     dataset_out = atlas.map_data(
         identifier=dataset_identifier,
@@ -699,7 +701,7 @@ def test_map_text_explicit_nomic_project(mock_map_data, mock_wait_for_completion
 def test_integration_map_embeddings_auto_with_options():
     num_embeddings = 50  # Small dataset, backend should pick UMAP if it has logic for it
     embeddings = np.random.rand(num_embeddings, 10)
-    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
+    data_payload = [{"description": "test_value"} for _ in range(num_embeddings)]
 
     dataset_identifier = f"unittest-auto-opts-{gen_temp_identifier()}"
     dataset = atlas.map_data(
@@ -724,7 +726,7 @@ def test_integration_map_embeddings_auto_with_options():
 def test_integration_map_embeddings_legacy_dict_with_explicit_algorithm():
     num_embeddings = 50
     embeddings = np.random.rand(num_embeddings, 10)
-    data_payload = [{'description': 'test_value'} for _ in range(num_embeddings)]
+    data_payload = [{"description": "test_value"} for _ in range(num_embeddings)]
 
     # Test with explicit algorithm="umap"
     dataset_identifier = f"unittest-legacy-dict-algo-umap-{gen_temp_identifier()}"
@@ -782,10 +784,5 @@ def test_integration_map_images():
 
     # Additional assertions can be added here, e.g., checking dataset.total_datums
     assert dataset.total_datums == size
-
-    # Check if topics can be accessed (even if empty, should not error)
-    # Depending on default topic modeling for images, this might need adjustment
-    # For now, let's assume topics might be generated or accessible without error.
-    assert isinstance(projection.topics.metadata, list)  # or dict, check actual type
 
     dataset.delete()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make unique ID field optional in Atlas SDK, updating logic and tests to handle datasets without mandatory unique IDs.
> 
>   - **Behavior**:
>     - Removed default ID generation logic in `map_data()` in `atlas.py`.
>     - Updated `AtlasDataset` to make `unique_id_field` optional.
>     - Modified `AtlasMapDuplicates`, `AtlasMapTopics`, `AtlasMapEmbeddings`, and `AtlasMapTags` to handle cases without a unique ID field.
>   - **Error Handling**:
>     - Added synthetic ID generation in `data_operations.py` when `unique_id_field` is not provided.
>     - Updated `_validate_and_correct_arrow_upload()` in `dataset.py` to skip ID validation if not specified.
>   - **Tests**:
>     - Updated tests in `test_atlas_client.py` to remove reliance on unique ID fields.
>     - Added checks for handling datasets without unique ID fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for d4292de2ef761dae876cda622c9ff6883275092f. You can [customize](https://app.ellipsis.dev/nomic-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->