### PR TITLE
add nomic-embed-text-v2

### DIFF
--- a/nomic/data_inference.py
+++ b/nomic/data_inference.py
@@ -130,5 +130,6 @@ class NomicEmbedOptions(BaseModel):
         "nomic-embed-vision-v1",
         "nomic-embed-text-v1.5",
         "nomic-embed-vision-v1.5",
+        "nomic-embed-text-v2",
         "gte-multilingual-base",
     ] = "nomic-embed-text-v1.5"


### PR DESCRIPTION
add nomic-embed-text-v2 to list of models allowed for create_index

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `nomic-embed-text-v2` to allowed models in `NomicEmbedOptions` for `create_index`.
> 
>   - **Models**:
>     - Add `nomic-embed-text-v2` to `NomicEmbedOptions` in `nomic/data_inference.py` for `create_index` model options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for b6ac09457f0b872d703979f7b10e5f4a29596da2. You can [customize](https://app.ellipsis.dev/nomic-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->