### PR TITLE
chore: get rid of get atoms

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -700,33 +700,6 @@ class AtlasProjection:
     def tile_destination(self):
         return Path("~/.nomic/cache", self.id).expanduser()
 
-    def _get_atoms(self, ids: List[str]) -> List[Dict]:
-        """
-        Retrieves atoms by id
-
-        Args:
-            ids: list of atom ids
-
-        Returns:
-            A dictionary containing the resulting atoms, keyed by atom id.
-
-        """
-
-        if not isinstance(ids, list):
-            raise ValueError("You must specify a list of ids when getting data.")
-
-        response = requests.post(
-            self.dataset.atlas_api_path + "/v1/project/atoms/get",
-            headers=self.dataset.header,
-            json={"project_id": self.dataset.id, "index_id": self.atlas_index_id, "atom_ids": ids},
-        )
-
-        if response.status_code == 200:
-            return response.json()["atoms"]
-        else:
-            raise Exception(response.text)
-
-
 class AtlasDataStream(AtlasClass):
     def __init__(self, name: Optional[str] = "contrastors"):
         super().__init__()

--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -700,6 +700,7 @@ class AtlasProjection:
     def tile_destination(self):
         return Path("~/.nomic/cache", self.id).expanduser()
 
+
 class AtlasDataStream(AtlasClass):
     def __init__(self, name: Optional[str] = "contrastors"):
         super().__init__()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `_get_atoms()` from `nomic/dataset.py`, simplifying the code by eliminating unused functionality.
> 
>   - **Removal**:
>     - Remove `_get_atoms()` from `nomic/dataset.py`, which retrieved atoms by ID using a POST request to the Atlas API.
>   - **Rationale**:
>     - Likely replaced by `get_data()` method, which retrieves data by IDs.
>     - Simplifies code by removing unused or redundant functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for fbe93fe0f56c2003a92a7ad44efd9ac1e2c9771f. You can [customize](https://app.ellipsis.dev/nomic-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->