### PR TITLE
fix: reduce upload workers to 2

### DIFF
--- a/nomic/dataset.py
+++ b/nomic/dataset.py
@@ -1566,12 +1566,8 @@ class AtlasDataset(AtlasClass):
             None
         """
 
-        # Exactly 2 upload workers at a time.
-
         num_workers = 2
-
         # Each worker currently is too slow beyond a shard_size of 10000
-
         # The heuristic here is: Never let shards be more than 10,000 items,
         # OR more than 16MB uncompressed. Whichever is smaller.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reduce upload workers from 10 to 2 in `_add_blobs()`, `_add_data()`, and `update_maps()` in `nomic/dataset.py`.
> 
>   - **Concurrency**:
>     - Reduce `num_workers` from 10 to 2 in `_add_blobs()`, `_add_data()`, and `update_maps()` in `nomic/dataset.py`.
>   - **Functions Affected**:
>     - `_add_blobs()`: Handles image blob uploads.
>     - `_add_data()`: Manages low-level data uploads.
>     - `update_maps()`: Deprecated method for updating project maps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for 42e35f07d1f391eb0d77f8b3053b09876dd23a57. You can [customize](https://app.ellipsis.dev/nomic-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->