### PR TITLE
fix: reduce text-embedding api max request batch size to 10

### DIFF
--- a/nomic/embed.py
+++ b/nomic/embed.py
@@ -26,7 +26,7 @@ except ImportError:
 
 atlas_class: Optional[AtlasClass] = None
 
-MAX_TEXT_REQUEST_SIZE = 50
+MAX_TEXT_REQUEST_SIZE = 10
 MAX_IMAGE_REQUEST_SIZE = 512
 MIN_EMBEDDING_DIMENSIONALITY = 64
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reduce `MAX_TEXT_REQUEST_SIZE` from 50 to 10 in `nomic/embed.py`, affecting text embedding request batch size.
> 
>   - **Behavior**:
>     - Reduce `MAX_TEXT_REQUEST_SIZE` from 50 to 10 in `nomic/embed.py`, affecting batch size for text embedding requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fnomic&utm_source=github&utm_medium=referral)<sup> for b21913196dd17a1e38e04f183b0421f567266ccd. You can [customize](https://app.ellipsis.dev/nomic-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->